### PR TITLE
Add forgotten arguments to the kernel

### DIFF
--- a/src/kernels/backproject.cl
+++ b/src/kernels/backproject.cl
@@ -39,7 +39,7 @@ backproject_nearest (global float *sinogram,
     float sum = 0.0;
 
     for(int proj = offset; proj < n_projections; proj++) {
-        float h = axis_pos + bx * cos_lut[proj] - by * sin_lut[proj];
+        float h = axis_pos + bx * cos_lut[proj] + by * sin_lut[proj];
         sum += sinogram[(int)(proj * width + h)];
     }
 


### PR DESCRIPTION
Now everything is OK. BTW the two kernels don't give you the same slice (one flips, the other one not). If there is no particular reason for that I can change the one minus sign to plus.
