### PR TITLE
Fix fix_abnormal in the ffc kernel

### DIFF
--- a/src/kernels/ffc.cl
+++ b/src/kernels/ffc.cl
@@ -30,14 +30,17 @@ flat_correct (global float *corrected,
     const int gid = get_global_id(1) * get_global_size(0) + get_global_id(0);
     const int corr_idx = sinogram_input ? get_global_id(0) : gid;
     const float cdark = dark[corr_idx] * dark_scale;
-    float result = (data[gid] - cdark) / (flat[corr_idx] - cdark);
+    float result;
+
+    if (absorptivity) {
+        result = log ((flat[corr_idx] - cdark) / (data[gid] - cdark));
+    }
+    else {
+        result = (data[gid] - cdark) / (flat[corr_idx] - cdark);
+    }
 
     if (fix_abnormal && (isnan (result) || isinf (result))) {
         result = 0.0;
-    }
-
-    if (absorptivity) {
-        result = -log (result);
     }
 
     corrected[gid] = result;


### PR DESCRIPTION
Don't use logarithm if the pixel is set to 0 before and respect logarithm
domain.
This got lost during the last beam time somehow...
