### PR TITLE
Restructure I/O and add HDF5 support

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -367,6 +367,15 @@ Buffering
         Number of pre-allocated buffers.
 
 
+Monitoring
+----------
+
+.. gobj:class:: monitor
+
+    Inspects a data stream and prints size, location and associated metadata
+    keys on stdout.
+
+
 Slicing
 -------
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,6 +114,7 @@ endif ()
 
 if (HDF5_FOUND)
     list(APPEND read_misc_SRCS readers/ufo-hdf5-reader.c)
+    list(APPEND write_misc_SRCS writers/ufo-hdf5-writer.c)
     list(APPEND ufofilter_LIBS ${HDF5_LIBRARIES})
     include_directories(${HDF5_INCLUDE_DIRS})
     link_directories(${HDF5_LIBRARY_DIRS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ set(ufofilter_SRCS
     ufo-ordfilt-task.c
     ufo-pad-task.c
     ufo-polar-coordinates-task.c
+    ufo-read-task.c
     ufo-reduce-task.c
     ufo-remove-circle-task.c
     ufo-retrieve-phase-task.c
@@ -55,7 +56,12 @@ set(ufofilter_SRCS
     ufo-zeropad-task.c
     )
 
-set(ufoaux_SRCS ufo-priv.c)
+set(ufoaux_SRCS
+    ufo-priv.c)
+
+set(read_misc_SRCS
+    readers/ufo-reader.c
+    readers/ufo-edf-reader.c)
 
 file(GLOB ufofilter_KERNELS "kernels/*.cl")
 #}}}
@@ -84,17 +90,19 @@ pkg_check_modules(UFO_IR ufoir>=0.1)
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fopenmp")
 
 if (TIFF_FOUND)
-    list(APPEND ufofilter_SRCS ufo-read-task.c)
+    list(APPEND read_misc_SRCS readers/ufo-tiff-reader.c)
     list(APPEND ufofilter_SRCS ufo-write-task.c)
     list(APPEND ufofilter_LIBS ${TIFF_LIBRARIES})
     include_directories(${TIFF_INCLUDE_DIRS})
     link_directories(${TIFF_LIBRARY_DIRS})
+    set(HAVE_TIFF True)
 elseif (LIBTIFF4_INCLUDE_DIRS AND LIBTIFF4_LIBRARIES)
-    list(APPEND ufofilter_SRCS ufo-read-task.c)
+    list(APPEND read_misc_SRCS readers/ufo-tiff-reader.c)
     list(APPEND ufofilter_SRCS ufo-write-task.c)
     list(APPEND ufofilter_LIBS ${LIBTIFF4_LIBRARIES})
     include_directories(${LIBTIFF4_INCLUDE_DIRS})
     link_directories(${LIBTIFF4_LIBRARY_DIRS})
+    set(HAVE_TIFF True)
 endif ()
 
 if (UCA_INCLUDE_DIRS AND UCA_LIBRARIES)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,6 +80,7 @@ endif()
 #{{{ Dependency checks
 find_package(TIFF)
 find_package(clFFT)
+find_package(HDF5)
 
 pkg_check_modules(UCA libuca>=1.2)
 pkg_check_modules(OPENCV opencv)
@@ -103,6 +104,14 @@ elseif (LIBTIFF4_INCLUDE_DIRS AND LIBTIFF4_LIBRARIES)
     include_directories(${LIBTIFF4_INCLUDE_DIRS})
     link_directories(${LIBTIFF4_LIBRARY_DIRS})
     set(HAVE_TIFF True)
+endif ()
+
+if (HDF5_FOUND)
+    list(APPEND read_misc_SRCS readers/ufo-hdf5-reader.c)
+    list(APPEND ufofilter_LIBS ${HDF5_LIBRARIES})
+    include_directories(${HDF5_INCLUDE_DIRS})
+    link_directories(${HDF5_LIBRARY_DIRS})
+    set(HAVE_HDF5 True)
 endif ()
 
 if (UCA_INCLUDE_DIRS AND UCA_LIBRARIES)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,7 @@ set(ufofilter_SRCS
     ufo-swap-quadrants-task.c
     ufo-subtract-task.c
     ufo-volume-render-task.c
+    ufo-write-task.c
     ufo-zeropad-task.c
     )
 
@@ -63,6 +64,9 @@ set(ufoaux_SRCS
 set(read_misc_SRCS
     readers/ufo-reader.c
     readers/ufo-edf-reader.c)
+
+set(write_misc_SRCS
+    writers/ufo-writer.c)
 
 file(GLOB ufofilter_KERNELS "kernels/*.cl")
 #}}}
@@ -93,14 +97,14 @@ set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fopenmp")
 
 if (TIFF_FOUND)
     list(APPEND read_misc_SRCS readers/ufo-tiff-reader.c)
-    list(APPEND ufofilter_SRCS ufo-write-task.c)
+    list(APPEND write_misc_SRCS writers/ufo-tiff-writer.c)
     list(APPEND ufofilter_LIBS ${TIFF_LIBRARIES})
     include_directories(${TIFF_INCLUDE_DIRS})
     link_directories(${TIFF_LIBRARY_DIRS})
     set(HAVE_TIFF True)
 elseif (LIBTIFF4_INCLUDE_DIRS AND LIBTIFF4_LIBRARIES)
     list(APPEND read_misc_SRCS readers/ufo-tiff-reader.c)
-    list(APPEND ufofilter_SRCS ufo-write-task.c)
+    list(APPEND write_misc_SRCS writers/ufo-tiff-writer.c)
     list(APPEND ufofilter_LIBS ${LIBTIFF4_LIBRARIES})
     include_directories(${LIBTIFF4_INCLUDE_DIRS})
     link_directories(${LIBTIFF4_LIBRARY_DIRS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,7 +66,8 @@ set(read_misc_SRCS
     readers/ufo-edf-reader.c)
 
 set(write_misc_SRCS
-    writers/ufo-writer.c)
+    writers/ufo-writer.c
+    writers/ufo-raw-writer.c)
 
 file(GLOB ufofilter_KERNELS "kernels/*.cl")
 #}}}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(ufofilter_SRCS
     ufo-measure-sharpness-task.c
     ufo-median-filter-task.c
     ufo-metaballs-task.c
+    ufo-monitor-task.c
     ufo-multi-search-task.c
     ufo-null-task.c
     ufo-opencl-task.c

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,3 +1,4 @@
 #cmakedefine HAVE_OCLFFT
 #cmakedefine HAVE_AMD
 #cmakedefine HAVE_TIFF
+#cmakedefine HAVE_HDF5

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,2 +1,3 @@
 #cmakedefine HAVE_OCLFFT
 #cmakedefine HAVE_AMD
+#cmakedefine HAVE_TIFF

--- a/src/readers/ufo-edf-reader.h
+++ b/src/readers/ufo-edf-reader.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef UFO_EDF_READER_EDF_H
+#define UFO_EDF_READER_EDF_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define UFO_TYPE_EDF_READER             (ufo_edf_reader_get_type())
+#define UFO_EDF_READER(obj)             (G_TYPE_CHECK_INSTANCE_CAST((obj), UFO_TYPE_EDF_READER, UfoEdfReader))
+#define UFO_IS_EDF_READER(obj)          (G_TYPE_CHECK_INSTANCE_TYPE((obj), UFO_TYPE_EDF_READER))
+#define UFO_EDF_READER_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST((klass), UFO_TYPE_EDF_READER, UfoEdfReaderClass))
+#define UFO_IS_EDF_READER_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE((klass), UFO_TYPE_EDF_READER))
+#define UFO_EDF_READER_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS((obj), UFO_TYPE_EDF_READER, UfoEdfReaderClass))
+
+
+typedef struct _UfoEdfReader           UfoEdfReader;
+typedef struct _UfoEdfReaderClass      UfoEdfReaderClass;
+typedef struct _UfoEdfReaderPrivate    UfoEdfReaderPrivate;
+
+struct _UfoEdfReader {
+    GObject parent_instance;
+
+    UfoEdfReaderPrivate *priv;
+};
+
+struct _UfoEdfReaderClass {
+    GObjectClass parent_class;
+};
+
+UfoEdfReader  *ufo_edf_reader_new       (void);
+GType          ufo_edf_reader_get_type  (void);
+
+G_END_DECLS
+
+#endif

--- a/src/readers/ufo-hdf5-reader.c
+++ b/src/readers/ufo-hdf5-reader.c
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <hdf5.h>
+#include "readers/ufo-reader.h"
+#include "readers/ufo-hdf5-reader.h"
+
+
+struct _UfoHdf5ReaderPrivate {
+    gchar *dataset;
+    hid_t file_id;
+    hid_t dataset_id;
+    hid_t src_dataspace_id;
+
+    gint n_dims;
+    hsize_t dims[3];
+    guint current;
+};
+
+static void ufo_reader_interface_init (UfoReaderIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (UfoHdf5Reader, ufo_hdf5_reader, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (UFO_TYPE_READER,
+                                                ufo_reader_interface_init))
+
+#define UFO_HDF5_READER_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE((obj), UFO_TYPE_HDF5_READER, UfoHdf5ReaderPrivate))
+
+UfoHdf5Reader *
+ufo_hdf5_reader_new (const gchar *dataset)
+{
+    UfoHdf5Reader *reader = g_object_new (UFO_TYPE_HDF5_READER, NULL);
+    reader->priv->dataset = g_strdup (dataset);
+    return reader;
+}
+
+static void
+ufo_hdf5_reader_open (UfoReader *reader,
+                      const gchar *filename)
+{
+    UfoHdf5ReaderPrivate *priv;
+
+    priv = UFO_HDF5_READER_GET_PRIVATE (reader);
+
+    priv->file_id = H5Fopen (filename, H5F_ACC_RDONLY, H5P_DEFAULT);
+    priv->dataset_id = H5Dopen (priv->file_id, priv->dataset, H5P_DEFAULT);
+    priv->src_dataspace_id = H5Dget_space (priv->dataset_id);
+    priv->n_dims = H5Sget_simple_extent_ndims (priv->src_dataspace_id);
+
+    if (priv->n_dims > 3)
+        g_error ("read:hdf5: no support for four-dimensional data");
+
+    H5Sget_simple_extent_dims (priv->src_dataspace_id, priv->dims, NULL);
+
+    priv->current = 0;
+}
+
+static void
+ufo_hdf5_reader_close (UfoReader *reader)
+{
+    UfoHdf5ReaderPrivate *priv;
+
+    priv = UFO_HDF5_READER_GET_PRIVATE (reader);
+
+    H5Sclose (priv->src_dataspace_id);
+    H5Dclose (priv->dataset_id);
+    H5Fclose (priv->file_id);
+}
+
+static gboolean
+ufo_hdf5_reader_data_available (UfoReader *reader)
+{
+    UfoHdf5ReaderPrivate *priv;
+
+    priv = UFO_HDF5_READER_GET_PRIVATE (reader);
+
+    return priv->current < priv->dims[0];
+}
+
+static void
+ufo_hdf5_reader_read (UfoReader *reader,
+                      UfoBuffer *buffer,
+                      UfoRequisition *requisition,
+                      guint roi_y,
+                      guint roi_height,
+                      guint roi_step)
+{
+    UfoHdf5ReaderPrivate *priv;
+    gpointer data;
+    hid_t dst_dataspace_id;
+    hsize_t dst_dims[2];
+
+    priv = UFO_HDF5_READER_GET_PRIVATE (reader);
+    data = ufo_buffer_get_host_array (buffer, NULL);
+
+    hsize_t offset[3] = { priv->current, roi_y, 0 };
+    hsize_t count[3] = { 1, roi_height, requisition->dims[0] };
+
+    dst_dims[0] = roi_height;
+    dst_dims[1] = requisition->dims[0];
+    dst_dataspace_id = H5Screate_simple (2, dst_dims, NULL);
+
+    H5Sselect_hyperslab (priv->src_dataspace_id, H5S_SELECT_SET, offset, NULL, count, NULL);
+    H5Dread (priv->dataset_id, H5T_NATIVE_FLOAT, dst_dataspace_id, priv->src_dataspace_id, H5P_DEFAULT, data);
+    H5Sclose (dst_dataspace_id);
+
+    priv->current++;
+}
+
+static void
+ufo_hdf5_reader_get_meta (UfoReader *reader,
+                          gsize *width,
+                          gsize *height,
+                          UfoBufferDepth *bitdepth)
+{
+    UfoHdf5ReaderPrivate *priv;
+
+    priv = UFO_HDF5_READER_GET_PRIVATE (reader);
+
+    *width = priv->dims[2];
+    *height = priv->dims[1];
+    *bitdepth = UFO_BUFFER_DEPTH_32F;
+}
+
+static void
+ufo_hdf5_reader_finalize (GObject *object)
+{
+    UfoHdf5ReaderPrivate *priv;
+
+    priv = UFO_HDF5_READER_GET_PRIVATE (object);
+    g_free (priv->dataset);
+    G_OBJECT_CLASS (ufo_hdf5_reader_parent_class)->finalize (object);
+}
+
+static void
+ufo_reader_interface_init (UfoReaderIface *iface)
+{
+    iface->open = ufo_hdf5_reader_open;
+    iface->close = ufo_hdf5_reader_close;
+    iface->read = ufo_hdf5_reader_read;
+    iface->get_meta = ufo_hdf5_reader_get_meta;
+    iface->data_available = ufo_hdf5_reader_data_available;
+}
+
+static void
+ufo_hdf5_reader_class_init(UfoHdf5ReaderClass *klass)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+    gobject_class->finalize = ufo_hdf5_reader_finalize;
+
+    g_type_class_add_private (gobject_class, sizeof (UfoHdf5ReaderPrivate));
+}
+
+static void
+ufo_hdf5_reader_init (UfoHdf5Reader *self)
+{
+    UfoHdf5ReaderPrivate *priv = NULL;
+
+    self->priv = priv = UFO_HDF5_READER_GET_PRIVATE (self);
+    priv->dataset = NULL;
+}

--- a/src/readers/ufo-hdf5-reader.h
+++ b/src/readers/ufo-hdf5-reader.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef UFO_HDF5_READER_HDF5_H
+#define UFO_HDF5_READER_HDF5_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define UFO_TYPE_HDF5_READER             (ufo_hdf5_reader_get_type())
+#define UFO_HDF5_READER(obj)             (G_TYPE_CHECK_INSTANCE_CAST((obj), UFO_TYPE_HDF5_READER, UfoHdf5Reader))
+#define UFO_IS_HDF5_READER(obj)          (G_TYPE_CHECK_INSTANCE_TYPE((obj), UFO_TYPE_HDF5_READER))
+#define UFO_HDF5_READER_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST((klass), UFO_TYPE_HDF5_READER, UfoHdf5ReaderClass))
+#define UFO_IS_HDF5_READER_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE((klass), UFO_TYPE_HDF5_READER))
+#define UFO_HDF5_READER_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS((obj), UFO_TYPE_HDF5_READER, UfoHdf5ReaderClass))
+
+
+typedef struct _UfoHdf5Reader           UfoHdf5Reader;
+typedef struct _UfoHdf5ReaderClass      UfoHdf5ReaderClass;
+typedef struct _UfoHdf5ReaderPrivate    UfoHdf5ReaderPrivate;
+
+struct _UfoHdf5Reader {
+    GObject parent_instance;
+
+    UfoHdf5ReaderPrivate *priv;
+};
+
+struct _UfoHdf5ReaderClass {
+    GObjectClass parent_class;
+};
+
+UfoHdf5Reader  *ufo_hdf5_reader_new       (const gchar *dataset);
+GType           ufo_hdf5_reader_get_type  (void);
+
+G_END_DECLS
+
+#endif

--- a/src/readers/ufo-reader.c
+++ b/src/readers/ufo-reader.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ufo-reader.h"
+
+typedef UfoReaderIface UfoReaderInterface;
+
+G_DEFINE_INTERFACE (UfoReader, ufo_reader, 0)
+
+
+void
+ufo_reader_open (UfoReader *reader,
+                 const gchar *filename)
+{
+    UFO_READER_GET_IFACE (reader)->open (reader, filename);
+}
+
+void
+ufo_reader_close (UfoReader *reader)
+{
+    UFO_READER_GET_IFACE (reader)->close (reader);
+}
+
+gboolean
+ufo_reader_data_available (UfoReader *reader)
+{
+    return UFO_READER_GET_IFACE (reader)->data_available (reader);
+}
+
+void
+ufo_reader_get_meta (UfoReader *reader,
+                     gsize *width,
+                     gsize *height,
+                     UfoBufferDepth *bitdepth)
+{
+    UFO_READER_GET_IFACE (reader)->get_meta (reader, width, height, bitdepth);
+}
+
+void
+ufo_reader_read (UfoReader *reader,
+                 UfoBuffer *buffer,
+                 UfoRequisition *requisition,
+                 guint roi_y,
+                 guint roi_height,
+                 guint roi_step)
+{
+    UFO_READER_GET_IFACE (reader)->read (reader, buffer, requisition, roi_y, roi_height, roi_step);
+}
+
+static void
+ufo_reader_default_init (UfoReaderInterface *iface)
+{
+}

--- a/src/readers/ufo-reader.h
+++ b/src/readers/ufo-reader.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef UFO_READER_H
+#define UFO_READER_H
+
+#include <ufo/ufo.h>
+
+G_BEGIN_DECLS
+
+#define UFO_TYPE_READER             (ufo_reader_get_type())
+#define UFO_READER(obj)             (G_TYPE_CHECK_INSTANCE_CAST((obj), UFO_TYPE_READER, UfoReader))
+#define UFO_IS_READER(obj)          (G_TYPE_CHECK_INSTANCE_TYPE((obj), UFO_TYPE_READER))
+#define UFO_READER_GET_IFACE(inst)  (G_TYPE_INSTANCE_GET_INTERFACE((inst), UFO_TYPE_READER, UfoReaderIface))
+
+
+typedef struct _UfoReader         UfoReader;
+typedef struct _UfoReaderIface    UfoReaderIface;
+
+
+struct _UfoReaderIface {
+    /*< private >*/
+    GTypeInterface parent_iface;
+
+    void        (*open)                 (UfoReader      *reader,
+                                         const gchar    *filename);
+    void        (*close)                (UfoReader      *reader);
+    gboolean    (*data_available)       (UfoReader      *reader);
+    void        (*get_meta)             (UfoReader      *reader,
+                                         gsize          *width,
+                                         gsize          *height,
+                                         guint          *bitdepth);
+    void        (*read)                 (UfoReader      *reader,
+                                         UfoBuffer      *buffer,
+                                         UfoRequisition *requisition,
+                                         guint           roi_y,
+                                         guint           roi_height,
+                                         guint           roi_step);
+};
+
+void        ufo_reader_open             (UfoReader      *reader,
+                                         const gchar    *filename);
+void        ufo_reader_close            (UfoReader      *reader);
+gboolean    ufo_reader_data_available   (UfoReader      *reader);
+void        ufo_reader_get_meta         (UfoReader      *reader,
+                                         gsize          *width,
+                                         gsize          *height,
+                                         UfoBufferDepth *bitdepth);
+void        ufo_reader_read             (UfoReader      *reader,
+                                         UfoBuffer      *buffer,
+                                         UfoRequisition *requisition,
+                                         guint           roi_y,
+                                         guint           roi_height,
+                                         guint           roi_step);
+
+GType  ufo_reader_get_type        (void);
+
+G_END_DECLS
+
+#endif
+

--- a/src/readers/ufo-tiff-reader.c
+++ b/src/readers/ufo-tiff-reader.c
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2011-2013 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <tiffio.h>
+
+#include "readers/ufo-reader.h"
+#include "readers/ufo-tiff-reader.h"
+
+
+struct _UfoTiffReaderPrivate {
+    TIFF    *tiff;
+    gboolean more;
+};
+
+static void ufo_reader_interface_init (UfoReaderIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (UfoTiffReader, ufo_tiff_reader, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (UFO_TYPE_READER,
+                                                ufo_reader_interface_init))
+
+#define UFO_TIFF_READER_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE((obj), UFO_TYPE_TIFF_READER, UfoTiffReaderPrivate))
+
+UfoTiffReader *
+ufo_tiff_reader_new (void)
+{
+    UfoTiffReader *reader = g_object_new (UFO_TYPE_TIFF_READER, NULL);
+    return reader;
+}
+
+static void
+ufo_tiff_reader_open (UfoReader *reader,
+                      const gchar *filename)
+{
+    UfoTiffReaderPrivate *priv;
+    
+    priv = UFO_TIFF_READER_GET_PRIVATE (reader);
+    priv->tiff = TIFFOpen (filename, "r");
+    priv->more = TRUE;
+}
+
+static void
+ufo_tiff_reader_close (UfoReader *reader)
+{
+    UfoTiffReaderPrivate *priv;
+    
+    priv = UFO_TIFF_READER_GET_PRIVATE (reader);
+    g_assert (priv->tiff != NULL);
+    TIFFClose (priv->tiff);
+    priv->tiff = NULL;
+}
+
+static gboolean
+ufo_tiff_reader_data_available (UfoReader *reader)
+{
+    UfoTiffReaderPrivate *priv;
+    
+    priv = UFO_TIFF_READER_GET_PRIVATE (reader);
+
+    return priv->more && priv->tiff != NULL;
+}
+
+static void
+ufo_tiff_reader_read (UfoReader *reader,
+                      UfoBuffer *buffer,
+                      UfoRequisition *requisition,
+                      guint roi_y,
+                      guint roi_height,
+                      guint roi_step)
+{
+    UfoTiffReaderPrivate *priv;
+    gchar *data;
+    tsize_t result;
+    gsize offset;
+    guint16 bits;
+    gsize step;
+
+    priv = UFO_TIFF_READER_GET_PRIVATE (reader);
+
+    TIFFGetField (priv->tiff, TIFFTAG_BITSPERSAMPLE, &bits);
+    step = requisition->dims[0] * bits / 8;
+    data = (gchar *) ufo_buffer_get_host_array (buffer, NULL);
+    offset = 0;
+
+    for (guint i = roi_y; i < roi_height; i += roi_step) {
+        result = TIFFReadScanline (priv->tiff, data + offset, i, 0);
+
+        if (result == -1) {
+            g_warning ("Cannot read scanline");
+            return;
+        }
+
+        offset += step;
+    }
+
+    priv->more = TIFFReadDirectory (priv->tiff) == 1;
+}
+
+static void
+ufo_tiff_reader_get_meta (UfoReader *reader,
+                          gsize *width,
+                          gsize *height,
+                          UfoBufferDepth *bitdepth)
+{
+    UfoTiffReaderPrivate *priv;
+    guint32 tiff_width;
+    guint32 tiff_height;
+    guint16 bits_per_sample;
+    
+    priv = UFO_TIFF_READER_GET_PRIVATE (reader);
+    g_assert (priv->tiff != NULL);
+
+    TIFFGetField (priv->tiff, TIFFTAG_IMAGEWIDTH, &tiff_width);
+    TIFFGetField (priv->tiff, TIFFTAG_IMAGELENGTH, &tiff_height);
+    TIFFGetField (priv->tiff, TIFFTAG_BITSPERSAMPLE, &bits_per_sample);
+
+    *width = (gsize) tiff_width;
+    *height = (gsize) tiff_height;
+
+    switch (bits_per_sample) {
+        case 8: 
+            *bitdepth = UFO_BUFFER_DEPTH_8U;
+            break;
+        case 16:
+            *bitdepth = UFO_BUFFER_DEPTH_16U;
+            break;
+        default:
+            *bitdepth = UFO_BUFFER_DEPTH_32F;
+    }
+}
+
+static void
+ufo_tiff_reader_finalize (GObject *object)
+{
+    UfoTiffReaderPrivate *priv;
+    
+    priv = UFO_TIFF_READER_GET_PRIVATE (object);
+
+    if (priv->tiff != NULL)
+        ufo_tiff_reader_close (UFO_READER (object));
+
+    G_OBJECT_CLASS (ufo_tiff_reader_parent_class)->finalize (object);
+}
+
+static void
+ufo_reader_interface_init (UfoReaderIface *iface)
+{
+    iface->open = ufo_tiff_reader_open;
+    iface->close = ufo_tiff_reader_close;
+    iface->read = ufo_tiff_reader_read;
+    iface->get_meta = ufo_tiff_reader_get_meta;
+    iface->data_available = ufo_tiff_reader_data_available;
+}
+
+static void
+ufo_tiff_reader_class_init(UfoTiffReaderClass *klass)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+    gobject_class->finalize = ufo_tiff_reader_finalize;
+
+    g_type_class_add_private (gobject_class, sizeof (UfoTiffReaderPrivate));
+}
+
+static void
+ufo_tiff_reader_init (UfoTiffReader *self)
+{
+    UfoTiffReaderPrivate *priv = NULL;
+
+    self->priv = priv = UFO_TIFF_READER_GET_PRIVATE (self);
+    priv->tiff = NULL;
+    priv->more = FALSE;
+}

--- a/src/readers/ufo-tiff-reader.h
+++ b/src/readers/ufo-tiff-reader.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef UFO_TIFF_READER_TIFF_H
+#define UFO_TIFF_READER_TIFF_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define UFO_TYPE_TIFF_READER             (ufo_tiff_reader_get_type())
+#define UFO_TIFF_READER(obj)             (G_TYPE_CHECK_INSTANCE_CAST((obj), UFO_TYPE_TIFF_READER, UfoTiffReader))
+#define UFO_IS_TIFF_READER(obj)          (G_TYPE_CHECK_INSTANCE_TYPE((obj), UFO_TYPE_TIFF_READER))
+#define UFO_TIFF_READER_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST((klass), UFO_TYPE_TIFF_READER, UfoTiffReaderClass))
+#define UFO_IS_TIFF_READER_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE((klass), UFO_TYPE_TIFF_READER))
+#define UFO_TIFF_READER_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS((obj), UFO_TYPE_TIFF_READER, UfoTiffReaderClass))
+
+
+typedef struct _UfoTiffReader           UfoTiffReader;
+typedef struct _UfoTiffReaderClass      UfoTiffReaderClass;
+typedef struct _UfoTiffReaderPrivate    UfoTiffReaderPrivate;
+
+struct _UfoTiffReader {
+    GObject parent_instance;
+
+    UfoTiffReaderPrivate *priv;
+};
+
+struct _UfoTiffReaderClass {
+    GObjectClass parent_class;
+};
+
+UfoTiffReader  *ufo_tiff_reader_new       (void);
+GType           ufo_tiff_reader_get_type  (void);
+
+G_END_DECLS
+
+#endif

--- a/src/ufo-monitor-task.c
+++ b/src/ufo-monitor-task.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ufo-priv.h"
+#include "ufo-monitor-task.h"
+
+
+static void ufo_task_interface_init (UfoTaskIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (UfoMonitorTask, ufo_monitor_task, UFO_TYPE_TASK_NODE,
+                         G_IMPLEMENT_INTERFACE (UFO_TYPE_TASK,
+                                                ufo_task_interface_init))
+
+#define UFO_MONITOR_TASK_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE((obj), UFO_TYPE_MONITOR_TASK, UfoMonitorTaskPrivate))
+
+
+UfoNode *
+ufo_monitor_task_new (void)
+{
+    return UFO_NODE (g_object_new (UFO_TYPE_MONITOR_TASK, NULL));
+}
+
+static void
+ufo_monitor_task_setup (UfoTask *task,
+                        UfoResources *resources,
+                        GError **error)
+{
+}
+
+static void
+ufo_monitor_task_get_requisition (UfoTask *task,
+                                  UfoBuffer **inputs,
+                                  UfoRequisition *requisition)
+{
+    ufo_buffer_get_requisition (inputs[0], requisition);
+}
+
+static guint
+ufo_monitor_task_get_num_inputs (UfoTask *task)
+{
+    return 1;
+}
+
+static guint
+ufo_monitor_task_get_num_dimensions (UfoTask *task,
+                                     guint input)
+{
+    return 2;
+}
+
+static UfoTaskMode
+ufo_monitor_task_get_mode (UfoTask *task)
+{
+    return UFO_TASK_MODE_PROCESSOR;
+}
+
+static gchar *
+join_list (GList *list, const gchar *sep)
+{
+    gchar **array;
+    GList *it;
+    gchar *result;
+    guint i = 0;
+
+    array = g_new0 (gchar *, g_list_length (list) + 1);
+
+    g_list_for (list, it)
+        array[i++] = it->data;
+
+    result = g_strjoinv (sep, array);
+    g_free (array);
+    return result;
+}
+
+static gboolean
+ufo_monitor_task_process (UfoTask *task,
+                          UfoBuffer **inputs,
+                          UfoBuffer *output,
+                          UfoRequisition *requisition)
+{
+    UfoBufferLocation location;
+    GList *keys;
+    GList *sizes;
+    gchar *keystring;
+    gchar *dimstring;
+
+    location = ufo_buffer_get_location (inputs[0]);
+    keys = ufo_buffer_get_metadata_keys (inputs[0]);
+    sizes = NULL;
+
+    for (guint i = 0; i < requisition->n_dims; i++)
+        sizes = g_list_append (sizes, g_strdup_printf ("%zu", requisition->dims[i]));
+
+    dimstring = join_list (sizes, " ");
+    keystring = join_list (keys, ", ");
+
+    g_print ("monitor: dims=[%s] keys=[%s] location=", dimstring, keystring);
+
+    switch (location) {
+        case UFO_BUFFER_LOCATION_HOST:
+            g_print ("host");
+            break;
+        case UFO_BUFFER_LOCATION_DEVICE:
+            g_print ("device");
+            break;
+        case UFO_BUFFER_LOCATION_DEVICE_IMAGE:
+            g_print ("image");
+            break;
+        case UFO_BUFFER_LOCATION_INVALID:
+            g_print ("invalid");
+            break;
+    }
+
+    g_print ("\n");
+    ufo_buffer_copy (inputs[0], output);
+
+    g_free (dimstring);
+    g_free (keystring);
+    g_list_free (keys);
+    g_list_free_full (sizes, (GDestroyNotify) g_free);
+
+    return TRUE;
+}
+
+static void
+ufo_task_interface_init (UfoTaskIface *iface)
+{
+    iface->setup = ufo_monitor_task_setup;
+    iface->get_num_inputs = ufo_monitor_task_get_num_inputs;
+    iface->get_num_dimensions = ufo_monitor_task_get_num_dimensions;
+    iface->get_mode = ufo_monitor_task_get_mode;
+    iface->get_requisition = ufo_monitor_task_get_requisition;
+    iface->process = ufo_monitor_task_process;
+}
+
+static void
+ufo_monitor_task_class_init (UfoMonitorTaskClass *klass)
+{
+}
+
+static void
+ufo_monitor_task_init(UfoMonitorTask *self)
+{
+}

--- a/src/ufo-monitor-task.h
+++ b/src/ufo-monitor-task.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __UFO_MONITOR_TASK_H
+#define __UFO_MONITOR_TASK_H
+
+#include <ufo/ufo.h>
+
+G_BEGIN_DECLS
+
+#define UFO_TYPE_MONITOR_TASK             (ufo_monitor_task_get_type())
+#define UFO_MONITOR_TASK(obj)             (G_TYPE_CHECK_INSTANCE_CAST((obj), UFO_TYPE_MONITOR_TASK, UfoMonitorTask))
+#define UFO_IS_MONITOR_TASK(obj)          (G_TYPE_CHECK_INSTANCE_TYPE((obj), UFO_TYPE_MONITOR_TASK))
+#define UFO_MONITOR_TASK_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST((klass), UFO_TYPE_MONITOR_TASK, UfoMonitorTaskClass))
+#define UFO_IS_MONITOR_TASK_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE((klass), UFO_TYPE_MONITOR_TASK))
+#define UFO_MONITOR_TASK_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS((obj), UFO_TYPE_MONITOR_TASK, UfoMonitorTaskClass))
+
+typedef struct _UfoMonitorTask           UfoMonitorTask;
+typedef struct _UfoMonitorTaskClass      UfoMonitorTaskClass;
+typedef struct _UfoMonitorTaskPrivate    UfoMonitorTaskPrivate;
+
+struct _UfoMonitorTask {
+    UfoTaskNode parent_instance;
+};
+
+struct _UfoMonitorTaskClass {
+    UfoTaskNodeClass parent_class;
+};
+
+UfoNode  *ufo_monitor_task_new       (void);
+GType     ufo_monitor_task_get_type  (void);
+
+G_END_DECLS
+
+#endif

--- a/src/ufo-read-task.c
+++ b/src/ufo-read-task.c
@@ -40,7 +40,7 @@ struct _UfoReadTaskPrivate {
     guint    current;
     guint    step;
     guint    start;
-    guint    end;
+    guint    number;
     gboolean done;
 
     UfoBufferDepth  depth;
@@ -70,7 +70,7 @@ enum {
     PROP_0,
     PROP_PATH,
     PROP_START,
-    PROP_END,
+    PROP_NUMBER,
     PROP_STEP,
     PROP_ROI_Y,
     PROP_ROI_HEIGHT,
@@ -132,12 +132,6 @@ ufo_read_task_setup (UfoTask *task,
     UfoReadTaskPrivate *priv;
 
     priv = UFO_READ_TASK_GET_PRIVATE (task);
-
-    if (priv->end <= priv->start) {
-        g_set_error (error, UFO_TASK_ERROR, UFO_TASK_ERROR_SETUP,
-                     "End must be less than start");
-        return;
-    }
 
     priv->filenames = read_filenames (priv->path);
 
@@ -251,7 +245,7 @@ ufo_read_task_generate (UfoTask *task,
 
     priv = UFO_READ_TASK_GET_PRIVATE (UFO_READ_TASK (task));
 
-    if (priv->current == priv->end || priv->done)
+    if (priv->current == priv->number || priv->done)
         return FALSE;
 
     ufo_reader_read (priv->reader, output, requisition, priv->roi_y, priv->roi_height, priv->roi_step);
@@ -294,8 +288,8 @@ ufo_read_task_set_property (GObject *object,
         case PROP_START:
             priv->start = g_value_get_uint (value);
             break;
-        case PROP_END:
-            priv->end = g_value_get_uint (value);
+        case PROP_NUMBER:
+            priv->number = g_value_get_uint (value);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -333,8 +327,8 @@ ufo_read_task_get_property (GObject *object,
         case PROP_START:
             g_value_set_uint (value, priv->start);
             break;
-        case PROP_END:
-            g_value_set_uint (value, priv->end);
+        case PROP_NUMBER:
+            g_value_set_uint (value, priv->number);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -444,11 +438,11 @@ ufo_read_task_class_init(UfoReadTaskClass *klass)
             0, G_MAXUINT, 0,
             G_PARAM_READWRITE);
 
-    properties[PROP_END] =
-        g_param_spec_uint("end",
-            "The files will be read until \"end\" - 1 index",
-            "The files will be read until \"end\" - 1 index",
-            1, G_MAXUINT, G_MAXUINT,
+    properties[PROP_NUMBER] =
+        g_param_spec_uint("number",
+            "Number of files that will be read at most",
+            "Number of files that will be read at most",
+            0, G_MAXUINT, G_MAXUINT,
             G_PARAM_READWRITE);
 
     for (guint i = PROP_0 + 1; i < N_PROPERTIES; i++)
@@ -470,7 +464,7 @@ ufo_read_task_init(UfoReadTask *self)
     priv->roi_step = 1;
     priv->convert = TRUE;
     priv->start = 0;
-    priv->end = G_MAXUINT;
+    priv->number = G_MAXUINT;
     priv->depth = UFO_BUFFER_DEPTH_32F;
 
     priv->edf_reader = ufo_edf_reader_new ();

--- a/src/ufo-read-task.c
+++ b/src/ufo-read-task.c
@@ -20,53 +20,42 @@
 #include <gmodule.h>
 #include <stdlib.h>
 #include <string.h>
-#include <tiffio.h>
 #include <glob.h>
 
+#include "config.h"
 #include "ufo-read-task.h"
 
-#define REGION_SIZE(start, stop, step) (((stop) - (start) - 1) / (step) + 1)
+#include "readers/ufo-reader.h"
+#include "readers/ufo-edf-reader.h"
 
-typedef enum {
-    TYPE_INVALID,
-    TYPE_TIFF,
-    TYPE_EDF,
-} FileType;
+#ifdef HAVE_TIFF
+#include "readers/ufo-tiff-reader.h"
+#endif
+
 
 struct _UfoReadTaskPrivate {
-    gchar *path;
-    guint count;
-    guint current_count;
-    guint step;
-    guint start;
-    guint end;
-    gboolean normalize;
-    gboolean more_pages;
-    GSList *filenames;
-    GSList *current_filename;
+    gchar   *path;
+    GList   *filenames;
+    GList   *current_element;
+    guint    current;
+    guint    step;
+    guint    start;
+    guint    end;
+    gboolean done;
 
-    /* General */
-    FileType opened_type;
-    UfoBufferDepth depth;
-    guint32 width;
-    guint32 height;
-    guint16 bps;
-    guint16 spp;
-    gsize size;
+    UfoBufferDepth  depth;
+    gboolean convert;
 
-    /* EDF */
-    FILE *edf;
-    gssize edf_file_size;
-    gboolean big_endian;
+    guint    roi_y;
+    guint    roi_height;
+    guint    roi_step;
 
-    /* TIFF */
-    TIFF *tiff;
+    UfoReader       *reader;
+    UfoEdfReader    *edf_reader;
 
-    gboolean enable_conversion;
-
-    guint roi_y;
-    guint roi_height;
-    guint roi_step;
+#ifdef HAVE_TIFF
+    UfoTiffReader   *tiff_reader;
+#endif
 };
 
 static void ufo_task_interface_init (UfoTaskIface *iface);
@@ -83,12 +72,10 @@ enum {
     PROP_START,
     PROP_END,
     PROP_STEP,
-    PROP_NORMALIZE,
     PROP_ROI_Y,
     PROP_ROI_HEIGHT,
     PROP_ROI_STEP,
-    PROP_TOTAL_HEIGHT,
-    PROP_ENABLE_CONVERSION,
+    PROP_CONVERT,
     N_PROPERTIES
 };
 
@@ -100,124 +87,59 @@ ufo_read_task_new (void)
     return UFO_NODE (g_object_new (UFO_TYPE_READ_TASK, NULL));
 }
 
-static guint
-compute_height (UfoReadTaskPrivate *priv)
+static GList *
+read_filenames (const gchar *path)
 {
-    guint height, roi_y;
+    GList *result;
+    gchar *pattern;
+    glob_t filenames;
 
-    roi_y = priv->roi_y >= priv->height ? 0 : priv->roi_y;
-    if (!priv->roi_height) {
-        height = priv->height - roi_y;
+    result = NULL;
+
+    if (g_file_test (path, G_FILE_TEST_IS_REGULAR)) {
+        /* This is a single file without any asterisks */
+        pattern = g_strdup (path);
     }
     else {
-        height = roi_y + priv->roi_height > priv->height ? priv->height - roi_y : priv->roi_height;
+        /* This is a directory which we may have to glob */
+        pattern = strstr (path, "*") != NULL ? g_strdup (path) : g_build_filename (path, "*", NULL);
     }
 
-    return height;
-}
+    glob (pattern, GLOB_MARK | GLOB_TILDE, NULL, &filenames);
 
-static gboolean
-read_tiff_data (UfoReadTaskPrivate *priv, gpointer buffer, UfoRequisition *requisition)
-{
-    const guint32 width = requisition->dims[0];
-    const guint32 roi_y = priv->roi_y >= priv->height ? 0 : priv->roi_y;
-    const guint32 height = roi_y + compute_height (priv);
-    tsize_t result;
-    int offset = 0;
-    int step = width;
+    for (guint i = 0; i < filenames.gl_pathc; i++) {
+        const gchar *filename = filenames.gl_pathv[i];
 
-    if (priv->bps > 8) {
-        if (priv->bps <= 16)
-            step *= 2;
-        else
-            step *= 4;
+#ifdef HAVE_TIFF
+        if (g_str_has_suffix (filename, ".tiff") || g_str_has_suffix (filename, ".tif"))
+            result = g_list_append (result, g_strdup (filename));
+#endif
+
+        if (g_str_has_suffix (filename, ".edf"))
+            result = g_list_append (result, g_strdup (filename));
     }
 
-    for (guint32 i = roi_y; i < height; i += priv->roi_step) {
-        result = TIFFReadScanline (priv->tiff, ((gchar *) buffer) + offset, i, 0);
-
-        if (result == -1)
-            return FALSE;
-
-        offset += step;
-    }
-
-    return TRUE;
-}
-
-static gboolean
-is_tiff_file (const gchar *filename)
-{
-    return g_str_has_suffix (filename, ".tiff") ||
-           g_str_has_suffix (filename, ".tif");
-}
-
-static gboolean
-is_edf_file (const gchar *filename)
-{
-    return g_str_has_suffix (filename, ".edf");
-}
-
-static gboolean
-has_valid_extension (const gchar *filename)
-{
-    return is_tiff_file (filename) || is_edf_file (filename);
-}
-
-static GSList *
-read_filenames (UfoReadTaskPrivate *priv)
-{
-    GSList *result = NULL;
-    gchar *pattern;
-    glob_t glob_vector;
-    guint i;
-    guint end;
-    guint num_globbed;
-
-    if (!has_valid_extension (priv->path) && (g_strrstr (priv->path, "*") == NULL))
-        pattern = g_build_filename (priv->path, "*", NULL);
-    else
-        pattern = g_strdup (priv->path);
-
-    glob (pattern, GLOB_MARK | GLOB_TILDE, NULL, &glob_vector);
-    num_globbed = (guint) glob_vector.gl_pathc;
-    end = priv->end == G_MAXUINT ? num_globbed : MIN(priv->end, num_globbed);
-
-    for (i = priv->start; i < end; i += priv->step) {
-        const gchar *filename = glob_vector.gl_pathv[i];
-
-        if (has_valid_extension (filename))
-            result = g_slist_append (result, g_strdup (filename));
-        else
-            g_warning ("Ignoring `%s'", filename);
-    }
-
-    globfree (&glob_vector);
+    globfree (&filenames);
     g_free (pattern);
     return result;
 }
 
 static void
 ufo_read_task_setup (UfoTask *task,
-                       UfoResources *resources,
-                       GError **error)
+                     UfoResources *resources,
+                     GError **error)
 {
-    UfoReadTask *node;
     UfoReadTaskPrivate *priv;
-    guint n_files;
-    guint partition;
-    guint index;
-    guint total;
 
-    node = UFO_READ_TASK (task);
-    priv = node->priv;
-
-    priv->filenames = read_filenames (priv);
+    priv = UFO_READ_TASK_GET_PRIVATE (task);
 
     if (priv->end <= priv->start) {
-        g_set_error (error, UFO_TASK_ERROR, UFO_TASK_ERROR_SETUP, "End must be less than start");
+        g_set_error (error, UFO_TASK_ERROR, UFO_TASK_ERROR_SETUP,
+                     "End must be less than start");
         return;
     }
+
+    priv->filenames = read_filenames (priv->path);
 
     if (priv->filenames == NULL) {
         g_set_error (error, UFO_TASK_ERROR, UFO_TASK_ERROR_SETUP,
@@ -225,215 +147,80 @@ ufo_read_task_setup (UfoTask *task,
         return;
     }
 
-    ufo_task_node_get_partition (UFO_TASK_NODE (task), &index, &total);
-    n_files = (priv->end - priv->start - 1) / priv->step + 1;
-    partition = n_files / total;
-    priv->current_count = index * partition;
-    priv->count = (index + 1) * partition;
-    priv->current_filename = g_slist_nth (priv->filenames, (guint) priv->current_count);
+    priv->filenames = g_list_sort (priv->filenames, (GCompareFunc) g_strcmp0);
+    priv->current_element = g_list_nth (priv->filenames, priv->start);
 }
 
-static void
-read_edf_metadata (UfoReadTaskPrivate *priv)
+static UfoReader *
+get_reader (UfoReadTaskPrivate *priv, const gchar *filename)
 {
-    gchar *header = g_malloc (1024);
-    gchar **tokens;
-    size_t num_bytes;
+#ifdef HAVE_TIFF
+    if (g_str_has_suffix (filename, ".tiff") || g_str_has_suffix (filename, ".tif")) {
+        return UFO_READER (priv->tiff_reader);
+    }
+#endif
 
-    num_bytes = fread (header, 1, 1024, priv->edf);
-
-    if (num_bytes != 1024) {
-        g_free (header);
-        fclose (priv->edf);
-        return;
+    if (g_str_has_suffix (filename, ".edf")) {
+        return UFO_READER (priv->edf_reader);
     }
 
-    tokens = g_strsplit(header, ";", 0);
-    priv->big_endian = FALSE;
-    priv->bps = 32;
-    priv->spp = 1;
-
-    for (guint i = 0; tokens[i] != NULL; i++) {
-        gchar **key_value;
-        gchar *key;
-        gchar *value;
-
-        key_value = g_strsplit (tokens[i], "=", 0);
-
-        if (key_value[0] == NULL || key_value[1] == NULL)
-            continue;
-
-        key = g_strstrip (key_value[0]);
-        value = g_strstrip (key_value[1]);
-
-        if (!g_strcmp0 (key, "Dim_1")) {
-            priv->width = (guint) atoi (value);
-        }
-        else if (!g_strcmp0 (key, "Dim_2")) {
-            priv->height = (guint) atoi (value);
-        }
-        else if (!g_strcmp0 (key, "Size")) {
-            priv->size = (guint) atoi (value);
-        }
-        else if (!g_strcmp0 (key, "DataType")) {
-            if (!g_strcmp0 (value, "UnsignedShort")) {
-                priv->depth = UFO_BUFFER_DEPTH_16U;
-                priv->bps = 16;
-            }
-            else if (!g_strcmp0 (value, "SignedInteger")) {
-                priv->depth = UFO_BUFFER_DEPTH_32S;
-                priv->bps = 32;
-            }
-            else if (!g_strcmp0 (value, "UnsignedLong")) {
-                /* UnsignedLong at ESRF has 32 bits */
-                priv->depth = UFO_BUFFER_DEPTH_32U;
-                priv->bps = 32;
-            }
-            else if (!g_strcmp0 (value, "Float") || !g_strcmp0 (value, "FloatValue")) {
-                priv->bps = 32;
-                priv->depth = UFO_BUFFER_DEPTH_32F;
-            }
-            else {
-                g_warning ("Unsupported data type");
-            }
-        }
-        else if (!g_strcmp0 (key, "ByteOrder") &&
-                 !g_strcmp0 (value, "HighByteFirst")) {
-            priv->big_endian = TRUE;
-        }
-
-        g_strfreev (key_value);
-    }
-
-    g_strfreev(tokens);
-    g_free(header);
-}
-
-static gboolean
-read_edf_data (UfoReadTaskPrivate *priv,
-               gpointer buffer,
-               UfoRequisition *requisition)
-{
-    gsize num_bytes;
-    /* Offset to the first row */
-    gssize offset;
-    /* size of the image width in bytes */
-    const gsize width = requisition->dims[0] * priv->bps / 8;
-    const guint32 roi_y = priv->roi_y >= priv->height ? 0 : priv->roi_y;
-    const guint32 height = roi_y + compute_height (priv);
-    const guint num_rows = REGION_SIZE (roi_y, height, priv->roi_step);
-    /* Last read row, +1 because it is actually read */
-    const guint last_row = roi_y + priv->roi_step * (num_rows - 1) + 1;
-    /* Position after the last image row */
-    const gsize end_position = (priv->height - last_row) * width;
-
-    offset = 0;
-    /* Go to the first desired row */
-    fseek (priv->edf, roi_y * width, SEEK_CUR);
-
-    if (priv->roi_step == 1) {
-        /* Read the full ROI at once if no stepping is specified */
-        num_bytes = fread ((gchar *) buffer, 1, width * (height - roi_y), priv->edf);
-        if (num_bytes != width * (height - roi_y)) {
-            return FALSE;
-        }
-    }
-    else {
-        for (guint32 i = 0; i < num_rows - 1; i++) {
-            num_bytes = fread (((gchar *) buffer) + offset, 1, width, priv->edf);
-
-            if (num_bytes != width)
-                return FALSE;
-
-            offset += width;
-            fseek (priv->edf, (priv->roi_step - 1) * width, SEEK_CUR);
-        }
-        /* Read the last row without moving the file pointer so that the fseek to
-         * the image end works properly */
-        num_bytes = fread (((gchar *) buffer) + offset, 1, width, priv->edf);
-        if (num_bytes != width)
-            return FALSE;
-    }
-
-    /* Go to the image end to be in a consistent state for the next read */
-    fseek (priv->edf, end_position, SEEK_CUR);
-
-    if ((G_BYTE_ORDER == G_LITTLE_ENDIAN) && priv->big_endian) {
-        guint32 *data = (guint32 *) buffer;
-        guint n_pixels = requisition->dims[0] * requisition->dims[1];
-
-        for (guint i = 0; i < n_pixels; i++)
-            data[i] = g_ntohl (data[i]);
-    }
-
-    return TRUE;
-}
-
-static gboolean
-open_next_file (UfoReadTaskPrivate *priv)
-{
-    if (priv->opened_type == TYPE_EDF)
-        return ftell (priv->edf) >= priv->edf_file_size;
-
-    return TRUE;
+    return NULL;
 }
 
 static void
 ufo_read_task_get_requisition (UfoTask *task,
-                                 UfoBuffer **inputs,
-                                 UfoRequisition *requisition)
+                               UfoBuffer **inputs,
+                               UfoRequisition *requisition)
 {
     UfoReadTaskPrivate *priv;
-    guint height, roi_y;
+    gsize width;
+    gsize height;
+    const gchar *filename;
 
     priv = UFO_READ_TASK_GET_PRIVATE (UFO_READ_TASK (task));
 
-    if (open_next_file (priv)) {
-        if ((priv->current_count < priv->count) && (priv->current_filename != NULL)) {
-            const gchar *name = (gchar *) priv->current_filename->data;
+    if (priv->reader == NULL) {
+        filename = (gchar *) priv->current_element->data;
+        priv->reader = get_reader (priv, filename);
+        ufo_reader_open (priv->reader, filename);
+    }
 
-            if (is_tiff_file (name)) {
-                if (priv->tiff != NULL)
-                    TIFFClose (priv->tiff);
+    if (!ufo_reader_data_available (priv->reader)) {
+        ufo_reader_close (priv->reader);
+        priv->current_element = g_list_nth (priv->current_element, priv->step);
 
-                priv->tiff = TIFFOpen (name, "r");
-                priv->opened_type = TYPE_TIFF;
-
-                TIFFGetField (priv->tiff, TIFFTAG_BITSPERSAMPLE, &priv->bps);
-                TIFFGetField (priv->tiff, TIFFTAG_SAMPLESPERPIXEL, &priv->spp);
-                TIFFGetField (priv->tiff, TIFFTAG_IMAGEWIDTH, &priv->width);
-                TIFFGetField (priv->tiff, TIFFTAG_IMAGELENGTH, &priv->height);
-
-                if (priv->bps == 16)
-                    priv->depth = UFO_BUFFER_DEPTH_16U;
-            }
-            else if (is_edf_file (name)) {
-                if (priv->edf != NULL) {
-                    fclose (priv->edf);
-                }
-
-                priv->edf = fopen (name, "rb");
-
-                fseek (priv->edf, 0L, SEEK_END);
-                priv->edf_file_size = (gsize) ftell (priv->edf);
-                fseek (priv->edf, 0L, SEEK_SET);
-
-                priv->opened_type = TYPE_EDF;
-                read_edf_metadata (priv);
-            }
+        if (priv->current_element == NULL) {
+            priv->done = TRUE;
+            priv->reader = NULL;
+            return;
+        }
+        else {
+            filename = (gchar *) priv->current_element->data;
+            priv->reader = get_reader (priv, filename);
+            ufo_reader_open (priv->reader, filename);
         }
     }
+
+    ufo_reader_get_meta (priv->reader, &width, &height, &priv->depth);
+
+    if (priv->roi_y >= height) {
+        g_warning ("read: vertical ROI start %i >= height %zu", priv->roi_y, height);
+        priv->roi_y = 0;
+    }
+
+    if (!priv->roi_height) {
+        priv->roi_height = height - priv->roi_y;
+    }
     else {
-        g_assert (priv->opened_type == TYPE_EDF);
-        read_edf_metadata (priv);
+        if (priv->roi_y + priv->roi_height > height) {
+            g_warning ("read: vertical ROI height %i >= height %zu", priv->roi_height, height);
+            priv->roi_height = height - priv->roi_y;
+        }
     }
 
     requisition->n_dims = 2;
-    requisition->dims[0] = priv->width;
-
-    roi_y = priv->roi_y >= priv->height ? 0 : priv->roi_y;
-    height = compute_height (priv);
-    requisition->dims[1] = REGION_SIZE (roi_y, roi_y + height, priv->roi_step);
+    requisition->dims[0] = width;
+    requisition->dims[1] = priv->roi_height / priv->roi_step;
 }
 
 static guint
@@ -457,63 +244,23 @@ ufo_read_task_get_mode (UfoTask *task)
 
 static gboolean
 ufo_read_task_generate (UfoTask *task,
-                          UfoBuffer *output,
-                          UfoRequisition *requisition)
+                        UfoBuffer *output,
+                        UfoRequisition *requisition)
 {
     UfoReadTaskPrivate *priv;
-    UfoProfiler *profiler;
 
     priv = UFO_READ_TASK_GET_PRIVATE (UFO_READ_TASK (task));
-    profiler = ufo_task_node_get_profiler (UFO_TASK_NODE (task));
 
-    if (priv->current_count < priv->count) {
-        gpointer data = ufo_buffer_get_host_array (output, NULL);
+    if (priv->current == priv->end || priv->done)
+        return FALSE;
 
+    ufo_reader_read (priv->reader, output, requisition, priv->roi_y, priv->roi_height, priv->roi_step);
 
-        if (open_next_file (priv)) {
-            if (priv->current_filename != NULL) {
-                ufo_profiler_start (profiler, UFO_PROFILER_TIMER_IO);
+    if ((priv->depth != UFO_BUFFER_DEPTH_32F) && priv->convert)
+        ufo_buffer_convert (output, priv->depth);
 
-                if (priv->tiff != NULL) {
-                    read_tiff_data (priv, data, requisition);
-                }
-                else if (priv->edf != NULL) {
-                    read_edf_data (priv, data, requisition);
-                }
-
-                ufo_profiler_stop (profiler, UFO_PROFILER_TIMER_IO);
-
-                priv->current_filename = g_slist_next(priv->current_filename);
-                priv->current_count++;
-            }
-            else {
-                return FALSE;
-            }
-        }
-        else {
-            g_assert (priv->opened_type == TYPE_EDF);
-
-            ufo_profiler_start (profiler, UFO_PROFILER_TIMER_IO);
-            read_edf_data (priv, data, requisition);
-            ufo_profiler_stop (profiler, UFO_PROFILER_TIMER_IO);
-
-            priv->current_count++;
-
-            if (open_next_file (priv))
-                priv->current_filename = g_slist_next(priv->current_filename);
-        }
-
-        ufo_profiler_start (profiler, UFO_PROFILER_TIMER_CPU);
-
-        if ((priv->depth != UFO_BUFFER_DEPTH_32F) && priv->enable_conversion) {
-            ufo_buffer_convert (output, priv->depth);
-        }
-
-        ufo_profiler_stop (profiler, UFO_PROFILER_TIMER_CPU);
-        return TRUE;
-    }
-
-    return FALSE;
+    priv->current++;
+    return TRUE;
 }
 
 static void
@@ -532,9 +279,6 @@ ufo_read_task_set_property (GObject *object,
         case PROP_STEP:
             priv->step = g_value_get_uint (value);
             break;
-        case PROP_NORMALIZE:
-            priv->normalize = g_value_get_boolean (value);
-            break;
         case PROP_ROI_Y:
             priv->roi_y = g_value_get_uint (value);
             break;
@@ -544,8 +288,8 @@ ufo_read_task_set_property (GObject *object,
         case PROP_ROI_STEP:
             priv->roi_step = g_value_get_uint (value);
             break;
-        case PROP_ENABLE_CONVERSION:
-            priv->enable_conversion = g_value_get_boolean (value);
+        case PROP_CONVERT:
+            priv->convert = g_value_get_boolean (value);
             break;
         case PROP_START:
             priv->start = g_value_get_uint (value);
@@ -574,9 +318,6 @@ ufo_read_task_get_property (GObject *object,
         case PROP_STEP:
             g_value_set_uint (value, priv->step);
             break;
-        case PROP_NORMALIZE:
-            g_value_set_boolean (value, priv->normalize);
-            break;
         case PROP_ROI_Y:
             g_value_set_uint (value, priv->roi_y);
             break;
@@ -586,11 +327,8 @@ ufo_read_task_get_property (GObject *object,
         case PROP_ROI_STEP:
             g_value_set_uint (value, priv->roi_step);
             break;
-        case PROP_TOTAL_HEIGHT:
-            g_value_set_uint (value, priv->height);
-            break;
-        case PROP_ENABLE_CONVERSION:
-            g_value_set_boolean (value, priv->enable_conversion);
+        case PROP_CONVERT:
+            g_value_set_boolean (value, priv->convert);
             break;
         case PROP_START:
             g_value_set_uint (value, priv->start);
@@ -605,22 +343,31 @@ ufo_read_task_get_property (GObject *object,
 }
 
 static void
+ufo_read_task_dispose (GObject *object)
+{
+    UfoReadTaskPrivate *priv;
+
+    priv = UFO_READ_TASK_GET_PRIVATE (object);
+
+    g_object_unref (priv->edf_reader);
+
+#ifdef HAVE_TIFF
+    g_object_unref (priv->tiff_reader);
+#endif
+}
+
+static void
 ufo_read_task_finalize (GObject *object)
 {
-    UfoReadTaskPrivate *priv = UFO_READ_TASK_GET_PRIVATE (object);
+    UfoReadTaskPrivate *priv;
+
+    priv = UFO_READ_TASK_GET_PRIVATE (object);
 
     g_free (priv->path);
     priv->path = NULL;
 
-    if (priv->tiff != NULL)
-        TIFFClose (priv->tiff);
-
-    if (priv->edf != NULL)
-        fclose (priv->edf);
-
     if (priv->filenames != NULL) {
-        g_slist_foreach (priv->filenames, (GFunc) g_free, NULL);
-        g_slist_free (priv->filenames);
+        g_list_free_full (priv->filenames, (GDestroyNotify) g_free);
         priv->filenames = NULL;
     }
 
@@ -645,6 +392,7 @@ ufo_read_task_class_init(UfoReadTaskClass *klass)
 
     gobject_class->set_property = ufo_read_task_set_property;
     gobject_class->get_property = ufo_read_task_get_property;
+    gobject_class->dispose = ufo_read_task_dispose;
     gobject_class->finalize = ufo_read_task_finalize;
 
     properties[PROP_PATH] =
@@ -659,13 +407,6 @@ ufo_read_task_class_init(UfoReadTaskClass *klass)
         "Read every \"step\" file",
         "Read every \"step\" file",
         1, G_MAXUINT, 1,
-        G_PARAM_READWRITE);
-
-    properties[PROP_NORMALIZE] =
-        g_param_spec_boolean("normalize",
-        "Normalize values",
-        "Whether 8-bit or 16-bit values are normalized to [0.0, 1.0]",
-        FALSE,
         G_PARAM_READWRITE);
 
     properties[PROP_ROI_Y] =
@@ -689,14 +430,7 @@ ufo_read_task_class_init(UfoReadTaskClass *klass)
             1, G_MAXUINT, 1,
             G_PARAM_READWRITE);
 
-    properties[PROP_TOTAL_HEIGHT] =
-        g_param_spec_uint("total-height",
-            "Total height of an image",
-            "Total height of an image",
-            0, G_MAXUINT, 0,
-            G_PARAM_READABLE);
-
-    properties[PROP_ENABLE_CONVERSION] =
+    properties[PROP_CONVERT] =
         g_param_spec_boolean("enable-conversion",
             "Enable automatic conversion",
             "Enable automatic conversion of input data types to float",
@@ -729,18 +463,22 @@ ufo_read_task_init(UfoReadTask *self)
     UfoReadTaskPrivate *priv = NULL;
 
     self->priv = priv = UFO_READ_TASK_GET_PRIVATE (self);
-    priv->path = g_strdup ("*.tif");
+    priv->path = g_strdup (".");
     priv->step = 1;
-    priv->normalize = FALSE;
-    priv->more_pages = FALSE;
     priv->roi_y = 0;
     priv->roi_height = 0;
     priv->roi_step = 1;
-    priv->tiff = NULL;
-    priv->edf = NULL;
-    priv->enable_conversion = TRUE;
+    priv->convert = TRUE;
     priv->start = 0;
     priv->end = G_MAXUINT;
     priv->depth = UFO_BUFFER_DEPTH_32F;
-    priv->opened_type = TYPE_INVALID;
+
+    priv->edf_reader = ufo_edf_reader_new ();
+
+#ifdef HAVE_TIFF
+    priv->tiff_reader = ufo_tiff_reader_new ();
+#endif
+
+    priv->reader = NULL;
+    priv->done = FALSE;
 }

--- a/src/ufo-read-task.c
+++ b/src/ufo-read-task.c
@@ -40,7 +40,6 @@ struct _UfoReadTaskPrivate {
     guint step;
     guint start;
     guint end;
-    gboolean blocking;
     gboolean normalize;
     gboolean more_pages;
     GSList *filenames;
@@ -81,7 +80,6 @@ G_DEFINE_TYPE_WITH_CODE (UfoReadTask, ufo_read_task, UFO_TYPE_TASK_NODE,
 enum {
     PROP_0,
     PROP_PATH,
-    PROP_BLOCKING,
     PROP_START,
     PROP_END,
     PROP_STEP,
@@ -534,9 +532,6 @@ ufo_read_task_set_property (GObject *object,
         case PROP_STEP:
             priv->step = g_value_get_uint (value);
             break;
-        case PROP_BLOCKING:
-            priv->blocking = g_value_get_boolean (value);
-            break;
         case PROP_NORMALIZE:
             priv->normalize = g_value_get_boolean (value);
             break;
@@ -578,9 +573,6 @@ ufo_read_task_get_property (GObject *object,
             break;
         case PROP_STEP:
             g_value_set_uint (value, priv->step);
-            break;
-        case PROP_BLOCKING:
-            g_value_set_boolean (value, priv->blocking);
             break;
         case PROP_NORMALIZE:
             g_value_set_boolean (value, priv->normalize);
@@ -669,13 +661,6 @@ ufo_read_task_class_init(UfoReadTaskClass *klass)
         1, G_MAXUINT, 1,
         G_PARAM_READWRITE);
 
-    properties[PROP_BLOCKING] =
-        g_param_spec_boolean("blocking",
-        "Block read",
-        "Block until all files are read.",
-        FALSE,
-        G_PARAM_READWRITE);
-
     properties[PROP_NORMALIZE] =
         g_param_spec_boolean("normalize",
         "Normalize values",
@@ -746,7 +731,6 @@ ufo_read_task_init(UfoReadTask *self)
     self->priv = priv = UFO_READ_TASK_GET_PRIVATE (self);
     priv->path = g_strdup ("*.tif");
     priv->step = 1;
-    priv->blocking = FALSE;
     priv->normalize = FALSE;
     priv->more_pages = FALSE;
     priv->roi_y = 0;

--- a/src/ufo-write-task.c
+++ b/src/ufo-write-task.c
@@ -18,28 +18,32 @@
  */
 
 #include <gmodule.h>
-#include <tiffio.h>
 #include <errno.h>
 
+#include "config.h"
 #include "ufo-write-task.h"
+#include "writers/ufo-writer.h"
 
-typedef enum {
-    BITS_8U = 8,
-    BITS_16U = 16,
-    BITS_32FP = 32,
-} BitDepth;
+#ifdef HAVE_TIFF
+#include "writers/ufo-tiff-writer.h"
+#endif
 
 struct _UfoWriteTaskPrivate {
-    gchar *format;
-    gchar *template;
+    gchar *filename;
     guint counter;
     gboolean append;
     gsize width;
     gsize height;
-    BitDepth depth;
+    UfoBufferDepth depth;
 
-    gboolean single;
-    TIFF *tif;
+    gboolean multi_file;
+    gboolean opened;
+
+    UfoWriter *writer;
+
+#ifdef HAVE_TIFF
+    UfoTiffWriter *tiff_writer;
+#endif
 };
 
 static void ufo_task_interface_init (UfoTaskIface *iface);
@@ -52,8 +56,7 @@ G_DEFINE_TYPE_WITH_CODE (UfoWriteTask, ufo_write_task, UFO_TYPE_TASK_NODE,
 
 enum {
     PROP_0,
-    PROP_FORMAT,
-    PROP_SINGLE_FILE,
+    PROP_FILENAME,
     PROP_APPEND,
     PROP_BITS,
     N_PROPERTIES
@@ -67,211 +70,95 @@ ufo_write_task_new (void)
     return UFO_NODE (g_object_new (UFO_TYPE_WRITE_TASK, NULL));
 }
 
-static void
-write_8bit_data (TIFF *tif, gfloat *data, gfloat min, gfloat max, guint width, guint height)
-{
-    guint8 *scanline;
-    const gfloat range = max - min;
-
-    TIFFSetField (tif, TIFFTAG_BITSPERSAMPLE, 8);
-    scanline = g_malloc (width);
-
-    for (guint y = 0; y < height; y++, data += width) {
-        for (guint i = 0; i < width; i++)
-            scanline[i] = (guint8) ((data[i] - min) / range * 255);
-
-        TIFFWriteScanline (tif, scanline, y, 0);
-    }
-
-    g_free (scanline);
-}
-
-static void
-write_16bit_data (TIFF *tif, gfloat *data, gfloat min, gfloat max, guint width, guint height)
-{
-    guint16 *scanline;
-    const gfloat range = max - min;
-
-    TIFFSetField (tif, TIFFTAG_BITSPERSAMPLE, 16);
-    scanline = g_malloc (width * 2);
-
-    for (guint y = 0; y < height; y++, data += width) {
-        for (guint i = 0; i < width; i++)
-            scanline[i] = (guint16) ((data[i] - min) / range * 65535);
-
-        TIFFWriteScanline (tif, scanline, y, 0);
-    }
-
-    g_free (scanline);
-}
-
-static gboolean
-write_tiff_data (UfoWriteTaskPrivate *priv, UfoBuffer *buffer)
-{
-    UfoRequisition requisition;
-    guint32 rows_per_strip;
-    gboolean success = TRUE;
-    gpointer data;
-    guint n_pages;
-    guint width, height;
-
-    ufo_buffer_get_requisition (buffer, &requisition);
-
-    /* With a 3-dimensional input buffer, we create z-depth TIFF pages. */
-    n_pages = requisition.n_dims == 3 ? (guint) requisition.dims[2] : 1;
-
-    width = (guint) requisition.dims[0];
-    height = (guint) requisition.dims[1];
-    data = ufo_buffer_get_host_array (buffer, NULL);
-
-    rows_per_strip = TIFFDefaultStripSize (priv->tif, (guint32) - 1);
-
-    if (n_pages > 1)
-        TIFFSetField (priv->tif, TIFFTAG_SUBFILETYPE, FILETYPE_PAGE);
-
-    for (guint i = 0; i < n_pages; i++) {
-        gfloat *start;
-
-        TIFFSetField (priv->tif, TIFFTAG_IMAGEWIDTH, width);
-        TIFFSetField (priv->tif, TIFFTAG_IMAGELENGTH, height);
-        TIFFSetField (priv->tif, TIFFTAG_SAMPLESPERPIXEL, 1);
-        TIFFSetField (priv->tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
-        TIFFSetField (priv->tif, TIFFTAG_ROWSPERSTRIP, rows_per_strip);
-        TIFFSetField (priv->tif, TIFFTAG_PAGENUMBER, i, n_pages);
-
-        start = ((gfloat *) data) + i * width * height;
-
-        if (priv->depth == BITS_32FP) {
-            TIFFSetField (priv->tif, TIFFTAG_BITSPERSAMPLE, 32);
-            TIFFSetField (priv->tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_IEEEFP);
-
-            for (guint y = 0; y < height; y++, start += width)
-                TIFFWriteScanline (priv->tif, start, y, 0);
-
-        }
-        else {
-            gfloat min, max;
-
-            min = ufo_buffer_min (buffer, NULL);
-            max = ufo_buffer_max (buffer, NULL);
-
-            TIFFSetField (priv->tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);
-
-            if (priv->depth == BITS_8U)
-                write_8bit_data (priv->tif, start, min, max, width, height);
-            else
-                write_16bit_data (priv->tif, start, min, max, width, height);
-        }
-
-        TIFFWriteDirectory (priv->tif);
-    }
-
-    return success;
-}
-
 static gchar *
-build_filename (UfoWriteTaskPrivate *priv)
+get_current_filename (UfoWriteTaskPrivate *priv)
 {
-    gchar *filename;
+    if (priv->multi_file)
+        return g_strdup (priv->filename);
 
-    if (priv->single)
-        filename = g_strdup (priv->format);
-    else
-        filename = g_strdup_printf (priv->template, priv->counter);
-
-    return filename;
+    return g_strdup_printf (priv->filename, priv->counter);
 }
 
-static void
-find_free_index (UfoWriteTaskPrivate *priv)
+static guint
+count_format_specifiers (const gchar *filename)
 {
-    while (g_file_test(build_filename(priv), G_FILE_TEST_EXISTS)) {
-        priv->counter++;
-    }
-}
+    guint count = 0;
 
-static gchar *
-build_template (const gchar *format)
-{
-    gchar *template;
-    gchar *percent;
+    do {
+        if (*filename == '%')
+            count++;
+    } while (*(filename++));
 
-    template = g_strdup (format);
-    percent = g_strstr_len (template, -1, "%");
-
-    if (percent != NULL) {
-        percent++;
-
-        while (*percent) {
-            if (*percent == '%')
-                *percent = '_';
-            percent++;
-        }
-    }
-    else {
-        g_warning ("Specifier %%i not found. Appending it.");
-        g_free (template);
-        template = g_strconcat (format, "%i", NULL);
-    }
-
-    return template;
-}
-
-static void
-open_tiff_file (UfoWriteTaskPrivate *priv)
-{
-    gchar *filename;
-    const gchar *mode = priv->append ? "a" : "w";
-
-    filename = build_filename (priv);
-    priv->tif = TIFFOpen (filename, mode);
-    g_free (filename);
+    return count;
 }
 
 static void
 ufo_write_task_setup (UfoTask *task,
-                       UfoResources *resources,
-                       GError **error)
+                      UfoResources *resources,
+                      GError **error)
 {
     UfoWriteTaskPrivate *priv;
-    guint index;
-    guint total;
+    gchar *basename;
+    gchar *dirname;
+    guint num_fmt_specifiers;
 
     priv = UFO_WRITE_TASK_GET_PRIVATE (task);
-    ufo_task_node_get_partition (UFO_TASK_NODE (task), &index, &total);
-    priv->counter = index * 1000;
+    num_fmt_specifiers = count_format_specifiers (priv->filename);
+    basename = g_path_get_basename (priv->filename);
+    dirname = g_path_get_dirname (priv->filename);
 
-    if (priv->single) {
-        open_tiff_file (priv);
+    if (num_fmt_specifiers > 1) {
+        g_set_error (error, UFO_TASK_ERROR, UFO_TASK_ERROR_SETUP,
+                     "`%s' has too many format specifiers", dirname);
+        return;
+    }
+
+    priv->multi_file = num_fmt_specifiers == 0;
+
+#ifdef HAVE_TIFF
+    if (g_str_has_suffix (basename, ".tiff") || g_str_has_suffix (basename, ".tif")) {
+        priv->writer = UFO_WRITER (priv->tiff_writer);
     }
     else {
-        gchar *dirname;
-
-        if (priv->template)
-            g_free (priv->template);
-
-        priv->template = build_template (priv->format);
-        dirname = g_path_get_dirname (priv->template);
-
-        if (g_strcmp0 (dirname, ".")) {
-            if (g_mkdir_with_parents (dirname, 0755)) {
-                g_set_error (error, G_FILE_ERROR, g_file_error_from_errno (errno),
-                             "Could not create directory `%s'", dirname);
-            }
-        }
-
-        if (priv->append) {
-            find_free_index(priv);
-        }
-
-        g_free (dirname);
+        g_set_error (error, UFO_TASK_ERROR, UFO_TASK_ERROR_SETUP,
+                     "`%s' does not have a valid file extension", basename);
+        return;
     }
+#endif
+
+    if (!g_file_test (dirname, G_FILE_TEST_EXISTS)) {
+        g_debug ("write: `%s' does not exist. Attempt to create it.", dirname);
+
+        if (g_mkdir_with_parents (dirname, 0755)) {
+            g_set_error (error, G_FILE_ERROR, g_file_error_from_errno (errno),
+                         "Could not create `%s'.", dirname);
+            return;
+        }
+    }
+
+    priv->counter = 0;
+
+    if (priv->append && !priv->multi_file) {
+        gboolean exists = TRUE;
+
+        while (exists) {
+            gchar *filename = get_current_filename (priv);
+            exists = g_file_test (filename, G_FILE_TEST_EXISTS);
+            g_free (filename);
+
+            if (exists)
+                priv->counter++;
+        }
+    }
+
+    g_free (dirname);
+    g_free (basename);
 }
 
 static void
 ufo_write_task_get_requisition (UfoTask *task,
-                                 UfoBuffer **inputs,
-                                 UfoRequisition *requisition)
+                                UfoBuffer **inputs,
+                                UfoRequisition *requisition)
 {
     requisition->n_dims = 0;
 }
@@ -298,64 +185,77 @@ ufo_write_task_get_mode (UfoTask *task)
 
 static gboolean
 ufo_write_task_process (UfoTask *task,
-                         UfoBuffer **inputs,
-                         UfoBuffer *output,
-                         UfoRequisition *requisition)
+                        UfoBuffer **inputs,
+                        UfoBuffer *output,
+                        UfoRequisition *requisition)
 {
     UfoWriteTaskPrivate *priv;
-    UfoProfiler *profiler;
+    UfoRequisition in_req;
+    guint8 *data;
+    guint num_frames;
+    gsize offset;
 
     priv = UFO_WRITE_TASK_GET_PRIVATE (UFO_WRITE_TASK (task));
-    profiler = ufo_task_node_get_profiler (UFO_TASK_NODE (task));
+    data = (guint8 *) ufo_buffer_get_host_array (inputs[0], NULL);
+    ufo_buffer_get_requisition (inputs[0], &in_req);
 
-    ufo_profiler_start (profiler, UFO_PROFILER_TIMER_IO);
+    num_frames = in_req.n_dims == 3 ? in_req.dims[2] : 1;
+    offset = ufo_buffer_get_size (inputs[0]) / num_frames;
 
-    if (!priv->single)
-        open_tiff_file (priv);
+    for (guint i = 0; i < num_frames; i++) {
+        if (!priv->multi_file || !priv->opened) {
+            gchar *filename = get_current_filename (priv);
+            ufo_writer_open (priv->writer, filename);
+            g_free (filename);
+            priv->opened = TRUE;
+        }
 
-    if (!write_tiff_data (priv, inputs[0]))
-        return FALSE;
+        ufo_writer_write (priv->writer, data + i * offset, &in_req, priv->depth);
 
-    if (!priv->single)
-        TIFFClose (priv->tif);
+        if (!priv->multi_file) {
+            ufo_writer_close (priv->writer);
+            priv->opened = FALSE;
+        }
 
-    ufo_profiler_stop (profiler, UFO_PROFILER_TIMER_IO);
+        priv->counter++;
+    }
 
-    priv->counter++;
     return TRUE;
 }
 
 static void
 ufo_write_task_set_property (GObject *object,
-                              guint property_id,
-                              const GValue *value,
-                              GParamSpec *pspec)
+                             guint property_id,
+                             const GValue *value,
+                             GParamSpec *pspec)
 {
     UfoWriteTaskPrivate *priv = UFO_WRITE_TASK_GET_PRIVATE (object);
 
     switch (property_id) {
-        case PROP_FORMAT:
-            g_free (priv->format);
-            priv->format = g_value_dup_string (value);
-            break;
-        case PROP_SINGLE_FILE:
-            priv->single = g_value_get_boolean (value);
+        case PROP_FILENAME:
+            g_free (priv->filename);
+            priv->filename = g_value_dup_string (value);
             break;
         case PROP_APPEND:
             priv->append = g_value_get_boolean (value);
             break;
         case PROP_BITS:
             {
-                guint val;
-
-                val = g_value_get_uint (value);
+                guint val = g_value_get_uint (value);
 
                 if (val != 8 && val != 16 && val != 32) {
                     g_warning ("Write::bits can only 8, 16 or 32");
                     return;
                 }
 
-                priv->depth = val;
+                if (val == 8)
+                    priv->depth = UFO_BUFFER_DEPTH_8U;
+
+                if (val == 16)
+                    priv->depth = UFO_BUFFER_DEPTH_16U;
+
+                if (val == 32)
+                    priv->depth = UFO_BUFFER_DEPTH_32F;
             }
             break;
         default:
@@ -366,29 +266,48 @@ ufo_write_task_set_property (GObject *object,
 
 static void
 ufo_write_task_get_property (GObject *object,
-                              guint property_id,
-                              GValue *value,
-                              GParamSpec *pspec)
+                             guint property_id,
+                             GValue *value,
+                             GParamSpec *pspec)
 {
     UfoWriteTaskPrivate *priv = UFO_WRITE_TASK_GET_PRIVATE (object);
 
     switch (property_id) {
-        case PROP_FORMAT:
-            g_value_set_string (value, priv->format);
-            break;
-        case PROP_SINGLE_FILE:
-            g_value_set_boolean (value, priv->single);
+        case PROP_FILENAME:
+            g_value_set_string (value, priv->filename);
             break;
         case PROP_APPEND:
             g_value_set_boolean (value, priv->append);
             break;
         case PROP_BITS:
-            g_value_set_uint (value, priv->depth);
+            if (priv->depth == UFO_BUFFER_DEPTH_8U)
+                g_value_set_uint (value, 8);
+
+            if (priv->depth == UFO_BUFFER_DEPTH_16U)
+                g_value_set_uint (value, 16);
+
+            if (priv->depth == UFO_BUFFER_DEPTH_32F)
+                g_value_set_uint (value, 32);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
             break;
     }
+}
+
+static void
+ufo_write_task_dispose (GObject *object)
+{
+    UfoWriteTaskPrivate *priv;
+
+    priv = UFO_WRITE_TASK_GET_PRIVATE (object);
+
+#ifdef HAVE_TIFF
+    if (priv->tiff_writer)
+        g_object_unref (priv->tiff_writer);
+#endif
+
+    G_OBJECT_CLASS (ufo_write_task_parent_class)->dispose (object);
 }
 
 static void
@@ -398,14 +317,8 @@ ufo_write_task_finalize (GObject *object)
 
     priv = UFO_WRITE_TASK_GET_PRIVATE (object);
 
-    if (priv->template)
-        g_free (priv->template);
-
-    if (priv->single)
-        TIFFClose (priv->tif);
-
-    g_free (priv->format);
-    priv->format= NULL;
+    g_free (priv->filename);
+    priv->filename= NULL;
 
     G_OBJECT_CLASS (ufo_write_task_parent_class)->finalize (object);
 }
@@ -428,20 +341,14 @@ ufo_write_task_class_init (UfoWriteTaskClass *klass)
 
     gobject_class->set_property = ufo_write_task_set_property;
     gobject_class->get_property = ufo_write_task_get_property;
+    gobject_class->dispose = ufo_write_task_dispose;
     gobject_class->finalize = ufo_write_task_finalize;
 
-    properties[PROP_FORMAT] =
+    properties[PROP_FILENAME] =
         g_param_spec_string ("filename",
-            "Filename format string",
-            "Format string of the path and filename. If multiple files are written it must contain a '%i' specifier denoting the current count",
+            "Filename filename string",
+            "filename string of the path and filename. If multiple files are written it must contain a '%i' specifier denoting the current count",
             "./output-%05i.tif",
-            G_PARAM_READWRITE);
-
-    properties[PROP_SINGLE_FILE] =
-        g_param_spec_boolean ("single-file",
-            "Whether to write a single file or a sequence of files",
-            "Whether to write a single file or a sequence of files",
-            FALSE,
             G_PARAM_READWRITE);
 
     properties[PROP_APPEND] =
@@ -467,10 +374,15 @@ static void
 ufo_write_task_init(UfoWriteTask *self)
 {
     self->priv = UFO_WRITE_TASK_GET_PRIVATE(self);
-    self->priv->format = g_strdup ("./output-%05i.tif");
-    self->priv->template = NULL;
     self->priv->counter = 0;
     self->priv->append = FALSE;
-    self->priv->single = FALSE;
-    self->priv->depth = 32;
+    self->priv->multi_file = FALSE;
+    self->priv->depth = UFO_BUFFER_DEPTH_32F;
+    self->priv->writer = NULL;
+    self->priv->opened = FALSE;
+
+#ifdef HAVE_TIFF
+    self->priv->tiff_writer = ufo_tiff_writer_new ();
+    self->priv->filename = g_strdup ("./output-%05i.tif");
+#endif
 }

--- a/src/ufo-write-task.h
+++ b/src/ufo-write-task.h
@@ -58,8 +58,8 @@ struct _UfoWriteTaskClass {
     UfoTaskNodeClass parent_class;
 };
 
-UfoNode  *ufo_write_task_new       (void);
-GType     ufo_write_task_get_type  (void);
+UfoNode  *ufo_write_task_new             (void);
+GType     ufo_write_task_get_type        (void);
 
 G_END_DECLS
 

--- a/src/writers/ufo-hdf5-writer.c
+++ b/src/writers/ufo-hdf5-writer.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <hdf5.h>
+
+#include "writers/ufo-writer.h"
+#include "writers/ufo-hdf5-writer.h"
+
+
+struct _UfoHdf5WriterPrivate {
+    gchar *dataset;
+    hid_t file_id;
+    hid_t dataset_id;
+    guint current;
+};
+
+static void ufo_writer_interface_init (UfoWriterIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (UfoHdf5Writer, ufo_hdf5_writer, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (UFO_TYPE_WRITER,
+                                                ufo_writer_interface_init))
+
+#define UFO_HDF5_WRITER_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE((obj), UFO_TYPE_HDF5_WRITER, UfoHdf5WriterPrivate))
+
+UfoHdf5Writer *
+ufo_hdf5_writer_new (const gchar *dataset)
+{
+    UfoHdf5Writer *writer = g_object_new (UFO_TYPE_HDF5_WRITER, NULL);
+    writer->priv->dataset = g_strdup (dataset);
+    return writer;
+}
+
+static void
+ufo_hdf5_writer_open (UfoWriter *writer,
+                     const gchar *filename)
+{
+    UfoHdf5WriterPrivate *priv;
+
+    priv = UFO_HDF5_WRITER_GET_PRIVATE (writer);
+
+    if (g_file_test (filename, G_FILE_TEST_EXISTS))
+        priv->file_id = H5Fopen (filename, H5F_ACC_RDWR, H5P_DEFAULT);
+    else
+        priv->file_id = H5Fcreate (filename, H5F_ACC_EXCL, H5P_DEFAULT, H5P_DEFAULT);
+
+    priv->current = 0;
+}
+
+static void
+ufo_hdf5_writer_close (UfoWriter *writer)
+{
+    UfoHdf5WriterPrivate *priv;
+
+    priv = UFO_HDF5_WRITER_GET_PRIVATE (writer);
+    H5Dclose (priv->dataset_id);
+    H5Fclose (priv->file_id);
+}
+
+static hid_t
+make_groups (hid_t file_id, const gchar *group_path)
+{
+    gchar **elements;
+    hid_t group_id;
+    hid_t new_group_id;
+
+    group_id = file_id;
+    elements = g_strsplit (group_path, "/", 0);
+
+    for (guint i = 0; elements[i] != NULL; i++) {
+        if (!g_strcmp0 (elements[i], ""))
+            continue;
+
+        new_group_id = H5Gcreate (group_id, elements[i], H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+
+        if (group_id != file_id)
+            H5Gclose (group_id);
+
+        group_id = new_group_id;
+    }
+
+    g_strfreev (elements);
+    return group_id;
+}
+
+static void
+ufo_hdf5_writer_write (UfoWriter *writer,
+                       gpointer data,
+                       UfoRequisition *requisition,
+                       UfoBufferDepth depth)
+{
+    UfoHdf5WriterPrivate *priv;
+    hid_t dst_dataspace_id;
+    hid_t src_dataspace_id;
+
+    priv = UFO_HDF5_WRITER_GET_PRIVATE (writer);
+
+    hsize_t offset[3] = { priv->current, 0, 0 };
+    hsize_t count[3] = { 1, requisition->dims[1], requisition->dims[0] };
+    hsize_t dims[3] = { priv->current + 1, requisition->dims[1], requisition->dims[0] };
+    hsize_t src_dims[2] = { requisition->dims[0], requisition->dims[1] };
+
+    if (priv->current == 0) {
+        /*
+         * HDF5 API ... yeah, this throws nasty warnings if it cannot find the
+         * data set, yet checking for existence of a data set is itself a
+         * horrendous adventure.
+         */
+        priv->dataset_id = H5Dopen (priv->file_id, priv->dataset, H5P_DEFAULT);
+
+        if (priv->dataset_id < 0) {
+            hid_t group_id;
+            hid_t dcpl;
+            hsize_t max_dims[3] = { H5S_UNLIMITED, requisition->dims[1], requisition->dims[0] };
+            gchar *group_path;
+
+            group_path = g_path_get_dirname (priv->dataset);
+            group_id = make_groups (priv->file_id, group_path);
+
+            g_free (group_path);
+
+            dst_dataspace_id = H5Screate_simple (3, dims, max_dims);
+            dcpl = H5Pcreate (H5P_DATASET_CREATE);
+            H5Pset_chunk (dcpl, 3, dims);
+            priv->dataset_id = H5Dcreate (group_id, priv->dataset, H5T_NATIVE_FLOAT, dst_dataspace_id,
+                                          H5P_DEFAULT, dcpl, H5P_DEFAULT);
+
+            H5Pclose (dcpl);
+            H5Sclose (dst_dataspace_id);
+        }
+    }
+    else {
+        H5Dset_extent (priv->dataset_id, dims);
+    }
+
+    dst_dataspace_id = H5Dget_space (priv->dataset_id);
+    src_dataspace_id = H5Screate_simple (2, src_dims, NULL);
+
+    H5Sselect_hyperslab (dst_dataspace_id, H5S_SELECT_SET, offset, NULL, count, NULL);
+    H5Dwrite (priv->dataset_id, H5T_NATIVE_FLOAT, src_dataspace_id, dst_dataspace_id, H5P_DEFAULT, data);
+
+    H5Sclose (src_dataspace_id);
+    H5Sclose (dst_dataspace_id);
+    priv->current++;
+}
+
+static void
+ufo_hdf5_writer_finalize (GObject *object)
+{
+    UfoHdf5WriterPrivate *priv;
+
+    priv = UFO_HDF5_WRITER_GET_PRIVATE (object);
+
+    G_OBJECT_CLASS (ufo_hdf5_writer_parent_class)->finalize (object);
+}
+
+static void
+ufo_writer_interface_init (UfoWriterIface *iface)
+{
+    iface->open = ufo_hdf5_writer_open;
+    iface->close = ufo_hdf5_writer_close;
+    iface->write = ufo_hdf5_writer_write;
+}
+
+static void
+ufo_hdf5_writer_class_init (UfoHdf5WriterClass *klass)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+    gobject_class->finalize = ufo_hdf5_writer_finalize;
+
+    g_type_class_add_private (gobject_class, sizeof (UfoHdf5WriterPrivate));
+}
+
+static void
+ufo_hdf5_writer_init (UfoHdf5Writer *self)
+{
+    UfoHdf5WriterPrivate *priv = NULL;
+
+    self->priv = priv = UFO_HDF5_WRITER_GET_PRIVATE (self);
+    priv->dataset = NULL;
+}

--- a/src/writers/ufo-hdf5-writer.h
+++ b/src/writers/ufo-hdf5-writer.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef UFO_HDF5_WRITER_HDF5_H
+#define UFO_HDF5_WRITER_HDF5_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define UFO_TYPE_HDF5_WRITER             (ufo_hdf5_writer_get_type())
+#define UFO_HDF5_WRITER(obj)             (G_TYPE_CHECK_INSTANCE_CAST((obj), UFO_TYPE_HDF5_WRITER, UfoHdf5Writer))
+#define UFO_IS_HDF5_WRITER(obj)          (G_TYPE_CHECK_INSTANCE_TYPE((obj), UFO_TYPE_HDF5_WRITER))
+#define UFO_HDF5_WRITER_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST((klass), UFO_TYPE_HDF5_WRITER, UfoHdf5WriterClass))
+#define UFO_IS_HDF5_WRITER_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE((klass), UFO_TYPE_HDF5_WRITER))
+#define UFO_HDF5_WRITER_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS((obj), UFO_TYPE_HDF5_WRITER, UfoHdf5WriterClass))
+
+
+typedef struct _UfoHdf5Writer           UfoHdf5Writer;
+typedef struct _UfoHdf5WriterClass      UfoHdf5WriterClass;
+typedef struct _UfoHdf5WriterPrivate    UfoHdf5WriterPrivate;
+
+struct _UfoHdf5Writer {
+    GObject parent_instance;
+
+    UfoHdf5WriterPrivate *priv;
+};
+
+struct _UfoHdf5WriterClass {
+    GObjectClass parent_class;
+};
+
+UfoHdf5Writer  *ufo_hdf5_writer_new       (const gchar *dataset);
+GType           ufo_hdf5_writer_get_type  (void);
+
+G_END_DECLS
+
+#endif

--- a/src/writers/ufo-raw-writer.c
+++ b/src/writers/ufo-raw-writer.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+
+#include "writers/ufo-writer.h"
+#include "writers/ufo-raw-writer.h"
+
+
+struct _UfoRawWriterPrivate {
+    FILE *fp;
+};
+
+static void ufo_writer_interface_init (UfoWriterIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (UfoRawWriter, ufo_raw_writer, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (UFO_TYPE_WRITER,
+                                                ufo_writer_interface_init))
+
+#define UFO_RAW_WRITER_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE((obj), UFO_TYPE_RAW_WRITER, UfoRawWriterPrivate))
+
+UfoRawWriter *
+ufo_raw_writer_new (void)
+{
+    UfoRawWriter *writer = g_object_new (UFO_TYPE_RAW_WRITER, NULL);
+    return writer;
+}
+
+static void
+ufo_raw_writer_open (UfoWriter *writer,
+                     const gchar *filename)
+{
+    UfoRawWriterPrivate *priv;
+    
+    priv = UFO_RAW_WRITER_GET_PRIVATE (writer);
+    priv->fp = fopen (filename, "wb");
+}
+
+static void
+ufo_raw_writer_close (UfoWriter *writer)
+{
+    UfoRawWriterPrivate *priv;
+    
+    priv = UFO_RAW_WRITER_GET_PRIVATE (writer);
+    g_assert (priv->fp != NULL);
+    fclose (priv->fp);
+    priv->fp = NULL;
+}
+
+static void
+ufo_raw_writer_write (UfoWriter *writer,
+                      gpointer data,
+                      UfoRequisition *requisition,
+                      UfoBufferDepth depth)
+{
+    UfoRawWriterPrivate *priv;
+    gsize size = sizeof (gfloat);
+
+    priv = UFO_RAW_WRITER_GET_PRIVATE (writer);
+
+    for (guint i = 0; i < requisition->n_dims; i++)
+        size *= requisition->dims[i];
+
+    fwrite (data, 1, size, priv->fp);
+}
+
+static void
+ufo_raw_writer_finalize (GObject *object)
+{
+    UfoRawWriterPrivate *priv;
+    
+    priv = UFO_RAW_WRITER_GET_PRIVATE (object);
+
+    if (priv->fp != NULL)
+        ufo_raw_writer_close (UFO_WRITER (object));
+
+    G_OBJECT_CLASS (ufo_raw_writer_parent_class)->finalize (object);
+}
+
+static void
+ufo_writer_interface_init (UfoWriterIface *iface)
+{
+    iface->open = ufo_raw_writer_open;
+    iface->close = ufo_raw_writer_close;
+    iface->write = ufo_raw_writer_write;
+}
+
+static void
+ufo_raw_writer_class_init(UfoRawWriterClass *klass)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+    gobject_class->finalize = ufo_raw_writer_finalize;
+
+    g_type_class_add_private (gobject_class, sizeof (UfoRawWriterPrivate));
+}
+
+static void
+ufo_raw_writer_init (UfoRawWriter *self)
+{
+    UfoRawWriterPrivate *priv = NULL;
+
+    self->priv = priv = UFO_RAW_WRITER_GET_PRIVATE (self);
+    priv->fp = NULL;
+}

--- a/src/writers/ufo-raw-writer.c
+++ b/src/writers/ufo-raw-writer.c
@@ -63,6 +63,20 @@ ufo_raw_writer_close (UfoWriter *writer)
     priv->fp = NULL;
 }
 
+static gsize
+bytes_per_pixel (UfoBufferDepth depth)
+{
+    switch (depth) {
+        case UFO_BUFFER_DEPTH_8U:
+            return 1;
+        case UFO_BUFFER_DEPTH_16U:
+        case UFO_BUFFER_DEPTH_16S:
+            return 2;
+        default:
+            return 4;
+    }
+}
+
 static void
 ufo_raw_writer_write (UfoWriter *writer,
                       gpointer data,
@@ -70,9 +84,11 @@ ufo_raw_writer_write (UfoWriter *writer,
                       UfoBufferDepth depth)
 {
     UfoRawWriterPrivate *priv;
-    gsize size = sizeof (gfloat);
+    gsize size = bytes_per_pixel (depth);
 
     priv = UFO_RAW_WRITER_GET_PRIVATE (writer);
+
+    ufo_writer_convert_inplace (data, requisition, depth);
 
     for (guint i = 0; i < requisition->n_dims; i++)
         size *= requisition->dims[i];

--- a/src/writers/ufo-raw-writer.h
+++ b/src/writers/ufo-raw-writer.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef UFO_RAW_WRITER_RAW_H
+#define UFO_RAW_WRITER_RAW_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define UFO_TYPE_RAW_WRITER             (ufo_raw_writer_get_type())
+#define UFO_RAW_WRITER(obj)             (G_TYPE_CHECK_INSTANCE_CAST((obj), UFO_TYPE_RAW_WRITER, UfoRawWriter))
+#define UFO_IS_RAW_WRITER(obj)          (G_TYPE_CHECK_INSTANCE_TYPE((obj), UFO_TYPE_RAW_WRITER))
+#define UFO_RAW_WRITER_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST((klass), UFO_TYPE_RAW_WRITER, UfoRawWriterClass))
+#define UFO_IS_RAW_WRITER_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE((klass), UFO_TYPE_RAW_WRITER))
+#define UFO_RAW_WRITER_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS((obj), UFO_TYPE_RAW_WRITER, UfoRawWriterClass))
+
+
+typedef struct _UfoRawWriter           UfoRawWriter;
+typedef struct _UfoRawWriterClass      UfoRawWriterClass;
+typedef struct _UfoRawWriterPrivate    UfoRawWriterPrivate;
+
+struct _UfoRawWriter {
+    GObject parent_instance;
+
+    UfoRawWriterPrivate *priv;
+};
+
+struct _UfoRawWriterClass {
+    GObjectClass parent_class;
+};
+
+UfoRawWriter  *ufo_raw_writer_new       (void);
+GType          ufo_raw_writer_get_type  (void);
+
+G_END_DECLS
+
+#endif

--- a/src/writers/ufo-tiff-writer.c
+++ b/src/writers/ufo-tiff-writer.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2011-2013 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <tiffio.h>
+
+#include "writers/ufo-writer.h"
+#include "writers/ufo-tiff-writer.h"
+
+
+struct _UfoTiffWriterPrivate {
+    TIFF *tiff;
+    guint page;
+};
+
+static void ufo_writer_interface_init (UfoWriterIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (UfoTiffWriter, ufo_tiff_writer, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (UFO_TYPE_WRITER,
+                                                ufo_writer_interface_init))
+
+#define UFO_TIFF_WRITER_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE((obj), UFO_TYPE_TIFF_WRITER, UfoTiffWriterPrivate))
+
+UfoTiffWriter *
+ufo_tiff_writer_new (void)
+{
+    UfoTiffWriter *writer = g_object_new (UFO_TYPE_TIFF_WRITER, NULL);
+    return writer;
+}
+
+static void
+ufo_tiff_writer_open (UfoWriter *writer,
+                      const gchar *filename)
+{
+    UfoTiffWriterPrivate *priv;
+    
+    priv = UFO_TIFF_WRITER_GET_PRIVATE (writer);
+    priv->tiff = TIFFOpen (filename, "w");
+    priv->page = 0;
+}
+
+static void
+ufo_tiff_writer_close (UfoWriter *writer)
+{
+    UfoTiffWriterPrivate *priv;
+    
+    priv = UFO_TIFF_WRITER_GET_PRIVATE (writer);
+    g_assert (priv->tiff != NULL);
+    TIFFClose (priv->tiff);
+    priv->tiff = NULL;
+}
+
+static void
+get_min_max (gfloat *data, UfoRequisition *requisition, gfloat *min, gfloat *max)
+{
+    gsize n_elements = requisition->dims[0] * requisition->dims[1];
+    gfloat cmax = -G_MAXFLOAT;
+    gfloat cmin = G_MAXFLOAT;
+
+    for (gsize i = 0; i < n_elements; i++) {
+        if (data[i] < cmin)
+            cmin = data[i];
+
+        if (data[i] > cmax)
+            cmax = data[i];
+    }
+
+    *max = cmax;
+    *min = cmin;
+}
+
+static void
+write_float_data (TIFF *tiff, gfloat *data, UfoRequisition *requisition)
+{
+    TIFFSetField (tiff, TIFFTAG_BITSPERSAMPLE, 32);
+    TIFFSetField (tiff, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_IEEEFP);
+
+    for (guint y = 0; y < requisition->dims[1]; y++, data += requisition->dims[0])
+        TIFFWriteScanline (tiff, data, y, 0);
+}
+
+static void
+write_8bit_data (TIFF *tiff, gfloat *data, UfoRequisition *requisition)
+{
+    guint8 *scanline;
+    guint width, height;
+    gfloat max, min;
+    gfloat range;
+    
+    get_min_max (data, requisition, &min, &max);
+    range = max - min;
+    width = requisition->dims[0];
+    height = requisition->dims[1];
+
+    TIFFSetField (tiff, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);
+    TIFFSetField (tiff, TIFFTAG_BITSPERSAMPLE, 8);
+
+    scanline = g_malloc (requisition->dims[0]);
+
+    for (guint y = 0; y < height; y++, data += width) {
+        for (guint i = 0; i < width; i++)
+            scanline[i] = (guint8) ((data[i] - min) / range * 255);
+
+        TIFFWriteScanline (tiff, scanline, y, 0);
+    }
+
+    g_free (scanline);
+}
+
+static void
+write_16bit_data (TIFF *tiff, gfloat *data, UfoRequisition *requisition) 
+{
+    guint16 *scanline;
+    guint width, height;
+    gfloat max, min;
+    gfloat range;
+    
+    get_min_max (data, requisition, &min, &max);
+    range = max - min;
+    width = requisition->dims[0];
+    height = requisition->dims[1];
+
+    TIFFSetField (tiff, TIFFTAG_BITSPERSAMPLE, 16);
+    scanline = g_malloc (width * 2);
+
+    for (guint y = 0; y < height; y++, data += width) {
+        for (guint i = 0; i < width; i++)
+            scanline[i] = (guint16) ((data[i] - min) / range * 65535);
+
+        TIFFWriteScanline (tiff, scanline, y, 0);
+    }
+
+    g_free (scanline);
+}
+
+static void
+ufo_tiff_writer_write (UfoWriter *writer,
+                       gpointer data,
+                       UfoRequisition *requisition,
+                       UfoBufferDepth depth)
+{
+    UfoTiffWriterPrivate *priv;
+
+    priv = UFO_TIFF_WRITER_GET_PRIVATE (writer);
+    g_assert (priv->tiff != NULL);
+
+    TIFFSetField (priv->tiff, TIFFTAG_SUBFILETYPE, FILETYPE_PAGE);
+    TIFFSetField (priv->tiff, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+    TIFFSetField (priv->tiff, TIFFTAG_IMAGEWIDTH, requisition->dims[0]);
+    TIFFSetField (priv->tiff, TIFFTAG_IMAGELENGTH, requisition->dims[1]);
+    TIFFSetField (priv->tiff, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize (priv->tiff, (guint32) - 1));
+
+    /*
+     * I seriously don't know if this is supposed to be supported by the format,
+     * but it's the only we way can write the page number without knowing the
+     * final number of pages in advance.
+     */
+    TIFFSetField (priv->tiff, TIFFTAG_PAGENUMBER, priv->page, priv->page);
+
+    switch (depth) {
+        case UFO_BUFFER_DEPTH_8U:
+            write_8bit_data (priv->tiff, data, requisition);
+            break;
+        case UFO_BUFFER_DEPTH_16U:
+        case UFO_BUFFER_DEPTH_16S:
+            write_16bit_data (priv->tiff, data, requisition);
+            break;
+        case UFO_BUFFER_DEPTH_32F:
+            write_float_data (priv->tiff, data, requisition);
+            break;
+        default:
+            g_warning ("write:tiff: 32 bit signed and unsigned not supported");
+    }
+
+    TIFFWriteDirectory (priv->tiff);
+    priv->page++;
+}
+
+static void
+ufo_tiff_writer_finalize (GObject *object)
+{
+    UfoTiffWriterPrivate *priv;
+    
+    priv = UFO_TIFF_WRITER_GET_PRIVATE (object);
+
+    if (priv->tiff != NULL)
+        ufo_tiff_writer_close (UFO_WRITER (object));
+
+    G_OBJECT_CLASS (ufo_tiff_writer_parent_class)->finalize (object);
+}
+
+static void
+ufo_writer_interface_init (UfoWriterIface *iface)
+{
+    iface->open = ufo_tiff_writer_open;
+    iface->close = ufo_tiff_writer_close;
+    iface->write = ufo_tiff_writer_write;
+}
+
+static void
+ufo_tiff_writer_class_init(UfoTiffWriterClass *klass)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+    gobject_class->finalize = ufo_tiff_writer_finalize;
+
+    g_type_class_add_private (gobject_class, sizeof (UfoTiffWriterPrivate));
+}
+
+static void
+ufo_tiff_writer_init (UfoTiffWriter *self)
+{
+    UfoTiffWriterPrivate *priv = NULL;
+
+    self->priv = priv = UFO_TIFF_WRITER_GET_PRIVATE (self);
+    priv->tiff = NULL;
+}

--- a/src/writers/ufo-tiff-writer.h
+++ b/src/writers/ufo-tiff-writer.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef UFO_TIFF_WRITER_TIFF_H
+#define UFO_TIFF_WRITER_TIFF_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define UFO_TYPE_TIFF_WRITER             (ufo_tiff_writer_get_type())
+#define UFO_TIFF_WRITER(obj)             (G_TYPE_CHECK_INSTANCE_CAST((obj), UFO_TYPE_TIFF_WRITER, UfoTiffWriter))
+#define UFO_IS_TIFF_WRITER(obj)          (G_TYPE_CHECK_INSTANCE_TYPE((obj), UFO_TYPE_TIFF_WRITER))
+#define UFO_TIFF_WRITER_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST((klass), UFO_TYPE_TIFF_WRITER, UfoTiffWriterClass))
+#define UFO_IS_TIFF_WRITER_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE((klass), UFO_TYPE_TIFF_WRITER))
+#define UFO_TIFF_WRITER_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS((obj), UFO_TYPE_TIFF_WRITER, UfoTiffWriterClass))
+
+
+typedef struct _UfoTiffWriter           UfoTiffWriter;
+typedef struct _UfoTiffWriterClass      UfoTiffWriterClass;
+typedef struct _UfoTiffWriterPrivate    UfoTiffWriterPrivate;
+
+struct _UfoTiffWriter {
+    GObject parent_instance;
+
+    UfoTiffWriterPrivate *priv;
+};
+
+struct _UfoTiffWriterClass {
+    GObjectClass parent_class;
+};
+
+UfoTiffWriter  *ufo_tiff_writer_new       (void);
+GType           ufo_tiff_writer_get_type  (void);
+
+G_END_DECLS
+
+#endif

--- a/src/writers/ufo-writer.c
+++ b/src/writers/ufo-writer.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ufo-writer.h"
+
+typedef UfoWriterIface UfoWriterInterface;
+
+G_DEFINE_INTERFACE (UfoWriter, ufo_writer, 0)
+
+
+void
+ufo_writer_open (UfoWriter *writer,
+                 const gchar *filename)
+{
+    UFO_WRITER_GET_IFACE (writer)->open (writer, filename);
+}
+
+void
+ufo_writer_close (UfoWriter *writer)
+{
+    UFO_WRITER_GET_IFACE (writer)->close (writer);
+}
+
+void
+ufo_writer_write (UfoWriter *writer,
+                  gpointer data,
+                  UfoRequisition *requisition,
+                  UfoBufferDepth depth)
+{
+    UFO_WRITER_GET_IFACE (writer)->write (writer, data, requisition, depth);
+}
+
+static void
+ufo_writer_default_init (UfoWriterInterface *iface)
+{
+}

--- a/src/writers/ufo-writer.c
+++ b/src/writers/ufo-writer.c
@@ -46,6 +46,105 @@ ufo_writer_write (UfoWriter *writer,
     UFO_WRITER_GET_IFACE (writer)->write (writer, data, requisition, depth);
 }
 
+static gsize
+get_num_elements (UfoRequisition *requisition)
+{
+    gsize count = 1;
+
+    for (guint i = 0; i < requisition->n_dims; i++)
+        count *= requisition->dims[i];
+
+    return count;
+}
+
+static void
+get_min_max (gfloat *data, UfoRequisition *requisition, gfloat *min, gfloat *max)
+{
+    gsize n_elements = get_num_elements (requisition);
+    gfloat cmax = -G_MAXFLOAT;
+    gfloat cmin = G_MAXFLOAT;
+
+    for (gsize i = 0; i < n_elements; i++) {
+        if (data[i] < cmin)
+            cmin = data[i];
+
+        if (data[i] > cmax)
+            cmax = data[i];
+    }
+
+    *max = cmax;
+    *min = cmin;
+}
+
+static void
+convert_to_8bit (gfloat *src, UfoRequisition *requisition)
+{
+    guint8 *dst;
+    gfloat max, min;
+    gsize n_elements;
+
+    get_min_max (src, requisition, &min, &max);
+    n_elements = get_num_elements (requisition);
+    dst = (guint8 *) src;
+
+    if (min >= 0.0 && max <= 255) {
+        for (gsize i = 0; i < n_elements; i++)
+            dst[i] = (guint16) src[i];
+    }
+    else {
+        gfloat range = max - min;
+
+        for (gsize i = 0; i < n_elements; i++)
+            dst[i] = (guint16) ((src[i] - min) / range * 255);
+    }
+}
+
+static void
+convert_to_16bit (gfloat *src, UfoRequisition *requisition)
+{
+    guint16 *dst;
+    gfloat max, min;
+    gsize n_elements;
+
+    get_min_max (src, requisition, &min, &max);
+    n_elements = get_num_elements (requisition);
+    dst = (guint16 *) src;
+
+    /* TODO: good opportunity for some SSE acceleration */
+    if (min >= 0.0 && max <= 65535) {
+        for (gsize i = 0; i < n_elements; i++)
+            dst[i] = (guint16) src[i];
+    }
+    else {
+        gfloat range = max - min;
+
+        for (gsize i = 0; i < n_elements; i++)
+            dst[i] = (guint16) ((src[i] - min) / range * 65535);
+    }
+}
+
+void
+ufo_writer_convert_inplace (gpointer data,
+                            UfoRequisition *requisition,
+                            UfoBufferDepth depth)
+{
+    /*
+     * Since we convert to data requiring less bytes per pixel than the native
+     * float format, we can do everything in-place.
+     */
+    switch (depth) {
+        case UFO_BUFFER_DEPTH_8U:
+            convert_to_8bit (data, requisition);
+            break;
+        case UFO_BUFFER_DEPTH_16U:
+        case UFO_BUFFER_DEPTH_16S:
+            convert_to_16bit (data, requisition);
+            break;
+        default:
+            break;
+    }
+}
+
 static void
 ufo_writer_default_init (UfoWriterInterface *iface)
 {

--- a/src/writers/ufo-writer.h
+++ b/src/writers/ufo-writer.h
@@ -54,6 +54,10 @@ void ufo_writer_write (UfoWriter      *writer,
                        gpointer        data,
                        UfoRequisition *requisition,
                        UfoBufferDepth  depth);
+void ufo_writer_convert_inplace
+                      (gpointer        data,
+                       UfoRequisition *requisition,
+                       UfoBufferDepth  depth);
 
 GType  ufo_writer_get_type        (void);
 

--- a/src/writers/ufo-writer.h
+++ b/src/writers/ufo-writer.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef UFO_WRITER_H
+#define UFO_WRITER_H
+
+#include <ufo/ufo.h>
+
+G_BEGIN_DECLS
+
+#define UFO_TYPE_WRITER             (ufo_writer_get_type())
+#define UFO_WRITER(obj)             (G_TYPE_CHECK_INSTANCE_CAST((obj), UFO_TYPE_WRITER, UfoWriter))
+#define UFO_IS_WRITER(obj)          (G_TYPE_CHECK_INSTANCE_TYPE((obj), UFO_TYPE_WRITER))
+#define UFO_WRITER_GET_IFACE(inst)  (G_TYPE_INSTANCE_GET_INTERFACE((inst), UFO_TYPE_WRITER, UfoWriterIface))
+
+
+typedef struct _UfoWriter         UfoWriter;
+typedef struct _UfoWriterIface    UfoWriterIface;
+
+
+struct _UfoWriterIface {
+    /*< private >*/
+    GTypeInterface parent_iface;
+
+    void (*open)     (UfoWriter      *writer,
+                      const gchar    *filename);
+    void (*close)    (UfoWriter      *writer);
+    void (*write)    (UfoWriter      *writer,
+                      gpointer        data,
+                      UfoRequisition *requisition,
+                      UfoBufferDepth  depth);
+};
+
+void ufo_writer_open  (UfoWriter      *writer,
+                       const gchar    *filename);
+void ufo_writer_close (UfoWriter      *writer);
+void ufo_writer_write (UfoWriter      *writer,
+                       gpointer        data,
+                       UfoRequisition *requisition,
+                       UfoBufferDepth  depth);
+
+GType  ufo_writer_get_type        (void);
+
+G_END_DECLS
+
+#endif
+


### PR DESCRIPTION
This PR changes the structure of the readers to fix things like #63 and ease addition of more readers, e.g. HDF5. As a nice side effect we can still build a basic EDF or HDF5 reader if libtiff is not available.

- [x] Allow ROI selection for HDF5 reading
- [x] Restructure writers too
- [x] Re-introduce writing received volumes
- [x] Fix writing to the same HDF5 group