### PR TITLE
Add calculate task

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -41,6 +41,30 @@ Flat-field correction
         If *TRUE*, replace all resulting NANs and INFs with zeros.
 
 
+Arithmetic expressions
+----------------------
+
+.. gobj:class:: calculate
+
+    Calculate an arithmetic expression. You have access to the value stored in
+    the input buffer via the *v* letter in :gobj:prop:`expression` and to the
+    index of *v* via letter *x*. Please be aware that *v* is a floating point
+    number while *x* is an integer. This is useful if you have multidimensional
+    data and want to address only one dimension. Let's say the input is two
+    dimensional, 256 pixels wide and you want to fill the x-coordinate with *x*
+    for all respective y-coordinates (a gradient in x-direction). Then you can
+    write *expression="x % 256"*. Another example is the *sinc* function which
+    you would calculate as *expression="sin(v) / x"* for 1D input.
+    For more complex math or other operations please consider using
+    :ref:`opencl <generic-opencl-ref>`.
+
+    .. gobj:prop:: expression
+
+        Arithmetic expression with math functions supported by OpenCL.
+
+
+.. _generic-opencl-ref:
+
 Generic OpenCL
 --------------
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set(ufofilter_SRCS
     ufo-backproject-task.c
     ufo-blur-task.c
     ufo-buffer-task.c
+    ufo-calculate-task.c
     ufo-cut-sinogram-task.c
     ufo-cut-roi-task.c
     ufo-center-of-rotation-task.c

--- a/src/ufo-calculate-task.c
+++ b/src/ufo-calculate-task.c
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2011-2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <string.h> 
+#include <glib.h>
+#include <glib/gprintf.h>
+
+#ifdef __APPLE__
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
+
+#include "ufo-calculate-task.h"
+
+
+struct _UfoCalculateTaskPrivate {
+    cl_context context;
+    cl_program program;
+    cl_kernel kernel;
+    gchar *expression;
+};
+
+static void ufo_task_interface_init (UfoTaskIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (UfoCalculateTask, ufo_calculate_task, UFO_TYPE_TASK_NODE,
+                         G_IMPLEMENT_INTERFACE (UFO_TYPE_TASK,
+                                                ufo_task_interface_init))
+
+#define UFO_CALCULATE_TASK_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE((obj), UFO_TYPE_CALCULATE_TASK, UfoCalculateTaskPrivate))
+
+enum {
+    PROP_0,
+    PROP_EXPRESSION,
+    N_PROPERTIES
+};
+
+static GParamSpec *properties[N_PROPERTIES] = { NULL, };
+
+static void
+make_kernel (UfoCalculateTaskPrivate *priv, UfoResources *resources, GError **error)
+{
+    const gchar *template = "kernel void calculate (global float *input, "\
+                            "global float *output) {int x = get_global_id (0); "\
+                            "float v = input[x]; output[x] = %s;}";
+    gchar default_expression[] = "0.0f";
+    gchar *source, *expression;
+        
+    expression = priv->expression == NULL ? default_expression : priv->expression;
+    source = (gchar *) g_try_malloc (strlen (template) + strlen (expression));
+
+    if (!source) {
+        g_warning ("Error allocating kernel string memory");
+    }
+    if (priv->kernel) {
+        UFO_RESOURCES_CHECK_CLERR (clReleaseKernel (priv->kernel));
+    }
+
+    if ((gsize) g_sprintf (source, template, expression) != strlen (source)) {
+        g_warning ("Error writing kernel source");
+    }
+    priv->kernel = ufo_resources_get_kernel_from_source(resources,
+                                                        source,
+                                                        "calculate",
+                                                        error);
+    g_free (source);
+}
+
+UfoNode *
+ufo_calculate_task_new (void)
+{
+    return UFO_NODE (g_object_new (UFO_TYPE_CALCULATE_TASK, NULL));
+}
+
+static void
+ufo_calculate_task_setup (UfoTask *task,
+                          UfoResources *resources,
+                          GError **error)
+{
+    UfoCalculateTaskPrivate *priv;
+
+    priv = UFO_CALCULATE_TASK_GET_PRIVATE (task);
+
+    priv->context = ufo_resources_get_context (resources);
+    UFO_RESOURCES_CHECK_CLERR (clRetainContext (priv->context));
+    make_kernel (priv, resources, error);
+}
+
+static void
+ufo_calculate_task_get_requisition (UfoTask *task,
+                                    UfoBuffer **inputs,
+                                    UfoRequisition *requisition)
+{
+    ufo_buffer_get_requisition (inputs[0], requisition);
+}
+
+static guint
+ufo_calculate_task_get_num_inputs (UfoTask *task)
+{
+    return 1;
+}
+
+static guint
+ufo_calculate_task_get_num_dimensions (UfoTask *task,
+                                       guint input)
+{
+    g_return_val_if_fail (input == 0, 0);
+    return 2;
+}
+
+static UfoTaskMode
+ufo_calculate_task_get_mode (UfoTask *task)
+{
+    return UFO_TASK_MODE_PROCESSOR | UFO_TASK_MODE_GPU;
+}
+
+static gboolean
+ufo_calculate_task_process (UfoTask *task,
+                            UfoBuffer **inputs,
+                            UfoBuffer *output,
+                            UfoRequisition *requisition)
+{
+    UfoCalculateTaskPrivate *priv;
+    UfoRequisition in_req;
+    UfoGpuNode *node;
+    UfoProfiler *profiler;
+    cl_command_queue *cmd_queue;
+    cl_mem in_mem;
+    cl_mem out_mem;
+    gsize global_work_size = 1;
+    guint i;
+
+    priv = UFO_CALCULATE_TASK_GET_PRIVATE (task);
+    ufo_buffer_get_requisition (inputs[0], &in_req);
+    node = UFO_GPU_NODE (ufo_task_node_get_proc_node (UFO_TASK_NODE(task)));
+    cmd_queue = ufo_gpu_node_get_cmd_queue (node);
+    in_mem = ufo_buffer_get_device_array (inputs[0], cmd_queue);
+    out_mem = ufo_buffer_get_device_array (output, cmd_queue);
+
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (priv->kernel, 0, sizeof (cl_mem), &in_mem));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (priv->kernel, 1, sizeof (cl_mem), &out_mem));
+
+    for (i = 0; i < in_req.n_dims; i++) {
+        global_work_size *= in_req.dims[i];
+    }
+    profiler = ufo_task_node_get_profiler (UFO_TASK_NODE (task));
+    ufo_profiler_call (profiler, cmd_queue, priv->kernel, 1, &global_work_size, NULL);
+
+    return TRUE;
+}
+
+static void
+ufo_calculate_task_set_property (GObject *object,
+                                 guint property_id,
+                                 const GValue *value,
+                                 GParamSpec *pspec)
+{
+    UfoCalculateTaskPrivate *priv = UFO_CALCULATE_TASK_GET_PRIVATE (object);
+
+    switch (property_id) {
+        case PROP_EXPRESSION:
+            priv->expression = g_value_dup_string (value);
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+            break;
+    }
+}
+
+static void
+ufo_calculate_task_get_property (GObject *object,
+                                 guint property_id,
+                                 GValue *value,
+                                 GParamSpec *pspec)
+{
+    UfoCalculateTaskPrivate *priv = UFO_CALCULATE_TASK_GET_PRIVATE (object);
+
+    switch (property_id) {
+        case PROP_EXPRESSION:
+            g_value_set_string (value, priv->expression);
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+            break;
+    }
+}
+
+static void
+ufo_calculate_task_finalize (GObject *object)
+{
+    UfoCalculateTaskPrivate *priv = UFO_CALCULATE_TASK_GET_PRIVATE (object);
+
+    if (priv->kernel) {
+        clReleaseKernel (priv->kernel);
+        priv->kernel = NULL;
+    }
+    if (priv->context) {
+        UFO_RESOURCES_CHECK_CLERR (clReleaseContext (priv->context));
+        priv->context = NULL;
+    }
+
+    g_free (priv->expression);
+
+    G_OBJECT_CLASS (ufo_calculate_task_parent_class)->finalize (object);
+}
+
+static void
+ufo_task_interface_init (UfoTaskIface *iface)
+{
+    iface->setup = ufo_calculate_task_setup;
+    iface->get_num_inputs = ufo_calculate_task_get_num_inputs;
+    iface->get_num_dimensions = ufo_calculate_task_get_num_dimensions;
+    iface->get_mode = ufo_calculate_task_get_mode;
+    iface->get_requisition = ufo_calculate_task_get_requisition;
+    iface->process = ufo_calculate_task_process;
+}
+
+static void
+ufo_calculate_task_class_init (UfoCalculateTaskClass *klass)
+{
+    GObjectClass *oclass = G_OBJECT_CLASS (klass);
+
+    oclass->set_property = ufo_calculate_task_set_property;
+    oclass->get_property = ufo_calculate_task_get_property;
+    oclass->finalize = ufo_calculate_task_finalize;
+
+    properties[PROP_EXPRESSION] =
+        g_param_spec_string ("expression",
+                             "Arithmetic expression to calculate",
+                             "Arithmetic expression to calculate, you can use \"v\""\
+                             "to access the values in the input and \"x\""\
+                             "to access the indices of the input values",
+                             "0.0f",
+                             G_PARAM_READWRITE);
+
+    for (guint i = PROP_0 + 1; i < N_PROPERTIES; i++)
+        g_object_class_install_property (oclass, i, properties[i]);
+
+    g_type_class_add_private (oclass, sizeof(UfoCalculateTaskPrivate));
+}
+
+static void
+ufo_calculate_task_init(UfoCalculateTask *self)
+{
+    self->priv = UFO_CALCULATE_TASK_GET_PRIVATE(self);
+    self->priv->expression = NULL;
+}

--- a/src/ufo-calculate-task.h
+++ b/src/ufo-calculate-task.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2011-2013 Karlsruhe Institute of Technology
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __UFO_CALCULATE_TASK_H
+#define __UFO_CALCULATE_TASK_H
+
+#include <ufo/ufo.h>
+
+G_BEGIN_DECLS
+
+#define UFO_TYPE_CALCULATE_TASK             (ufo_calculate_task_get_type())
+#define UFO_CALCULATE_TASK(obj)             (G_TYPE_CHECK_INSTANCE_CAST((obj), UFO_TYPE_CALCULATE_TASK, UfoCalculateTask))
+#define UFO_IS_CALCULATE_TASK(obj)          (G_TYPE_CHECK_INSTANCE_TYPE((obj), UFO_TYPE_CALCULATE_TASK))
+#define UFO_CALCULATE_TASK_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST((klass), UFO_TYPE_CALCULATE_TASK, UfoCalculateTaskClass))
+#define UFO_IS_CALCULATE_TASK_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE((klass), UFO_TYPE_CALCULATE_TASK))
+#define UFO_CALCULATE_TASK_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS((obj), UFO_TYPE_CALCULATE_TASK, UfoCalculateTaskClass))
+
+typedef struct _UfoCalculateTask           UfoCalculateTask;
+typedef struct _UfoCalculateTaskClass      UfoCalculateTaskClass;
+typedef struct _UfoCalculateTaskPrivate    UfoCalculateTaskPrivate;
+
+struct _UfoCalculateTask {
+    UfoTaskNode parent_instance;
+
+    UfoCalculateTaskPrivate *priv;
+};
+
+struct _UfoCalculateTaskClass {
+    UfoTaskNodeClass parent_class;
+};
+
+UfoNode  *ufo_calculate_task_new       (void);
+GType     ufo_calculate_task_get_type  (void);
+
+G_END_DECLS
+
+#endif


### PR DESCRIPTION
Simplifies calculating arithmetic expressions, especially useful with `ufo-launch`. You access the value in the input via `v` and it's index via `x` (I took the convention from ImageJ).

Examples:

* Initialize data with *1* or make x-gradient:
```bash
$ ufo-launch dummy-data ! calculate expression="1" ! null
$ ufo-launch dummy-data width=256 height=256 ! calculate expression="x % 256" ! null
```

* Take the negative logarithm of a flat-corrected projection:
```bash
$ ufo-launch read="flatcorr*.tif" ! calculate expression="-log(v)" ! null
```

* Compute sinc on 1D input:
```bash
$ ufo-launch dummy-data width=256 height=1 ! calculate expression="sin((float) x) / x" ! null
```
