### PR TITLE
Add ufo-filterhelp tool to get a list of available filters and maybe some useful infos

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -170,6 +170,8 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
+SET(FILTER_LIST "")
+
 foreach(_src ${ufofilter_SRCS})
     # find plugin suffix
     string(REGEX REPLACE "ufo-([^ \\.]+)-task.*" "\\1" task "${_src}")
@@ -183,6 +185,8 @@ foreach(_src ${ufofilter_SRCS})
     option(${target_option} "Build filter ${task}" ON)
 
     if (${target_option})
+        LIST(APPEND FILTER_LIST ${task}) 
+        
         set(_misc "${_misc}_misc_SRCS")
 
         string(REPLACE "-" "" _targetname ${task})
@@ -204,6 +208,11 @@ foreach(_src ${ufofilter_SRCS})
                 LIBRARY DESTINATION ${UFO_PLUGINDIR})
     endif()
 endforeach()
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/bin/ufo-filterhelp.c.in ufo-filterhelp.c)
+add_executable(ufo-filterhelp ufo-filterhelp.c)
+target_link_libraries(ufo-filterhelp ${ufofilter_LIBS})
+install(TARGETS ufo-filterhelp RUNTIME DESTINATION ${UFO_FILTERS_BINDIR})
 
 # copy kernels
 foreach(_kernel ${ufofilter_KERNELS})

--- a/src/bin/ufo-filterhelp.c.in
+++ b/src/bin/ufo-filterhelp.c.in
@@ -27,6 +27,7 @@ main(int argc, char* argv[])
 {
     GOptionContext *context;
     GError *error = NULL;
+    UfoPluginManager *pm;
 
     static gboolean filters = FALSE;
 
@@ -39,35 +40,79 @@ main(int argc, char* argv[])
     g_type_init ();
 #endif
 
-    context = g_option_context_new (NULL);
+    context = g_option_context_new ("TASK [TASK ...]");
+    g_option_context_set_summary (context, "Provides information about installed UFO filters and tasks");
     g_option_context_add_main_entries (context, entries, NULL);
 
     if (!g_option_context_parse (context, &argc, &argv, &error)) {
         g_print ("Error parsing options: %s\n", error->message);
         return 1;
     }
-    
-    if (argc == 1) {
-        if (filters) {
-            gchar **names = g_strsplit (filter_names, ";", -1);
-            if (!names) {
-                g_print ("No available filters could be found.\n");
-            }
-            else {
-                g_print ("The following tasks are available:\n");
-                guint i = 0; 
-                while (names[i]) {
-                    g_print ("%s\n", names[i]);
-                    i++;
-                }
-            }
-            g_strfreev (names);
+
+    if (filters) {
+        gchar **names = g_strsplit (filter_names, ";", -1);
+        if (!names) {
+            g_print ("No available filters could be found.\n");
         }
-        else
-            g_print ("%s", g_option_context_get_help (context, TRUE, NULL));
-        
+        else {
+            g_print ("The following filters and tasks are available:\n");
+            guint i = 0;
+            while (names[i]) {
+                g_print ("%s\n", names[i]);
+                i++;
+            }
+        }
+        g_strfreev (names);
         return 0;
     }
 
+    if (argc == 1) {
+        g_print ("%s", g_option_context_get_help (context, TRUE, NULL));
+        return 0;
+    }
+
+    pm = ufo_plugin_manager_new ();
+
+    for (gint i = 1; i < argc; i++) {
+        UfoTaskNode *node = ufo_plugin_manager_get_task (pm, argv[i], &error);
+
+        if (node) {
+            GObjectClass *node_class = G_OBJECT_GET_CLASS (node);
+
+            guint num_props = 0;
+            GParamSpec **pspecs = g_object_class_list_properties (node_class, &num_props);
+
+            if (pspecs) {
+                g_print ("#\n");
+                g_print ("# Filter '%s' exposes the following properties\n", argv[i]);
+                g_print ("#\n");
+                for (guint j = 0; j < num_props; j++) {
+                    g_print ("-- %s\n", pspecs[j]->name);
+                    g_print ("Type: %s\n", g_type_name (pspecs[j]->value_type));
+                    g_print ("Info: %s\n", g_param_spec_get_nick (pspecs[j]));
+                    g_print ("Description: %s\n", g_param_spec_get_blurb (pspecs[j]));
+                    g_print ("\n");
+                }
+            }
+
+            g_free (pspecs);
+            g_object_unref (node);
+        }
+        else {
+            g_print ("@\n");
+            if (error) {
+                g_print ("@ Warning: Could not find '%s' filter: %s\n", argv[i], error->message);
+                g_clear_error (&error);
+                error = NULL;
+            }
+            else {
+                g_print ("@ Warning: Could not find '%s' filter: An unknown error occured", argv[i]);
+            }
+            g_print ("@\n");
+        }
+    }
+
+    g_object_unref (pm);
+    g_option_context_free (context);
     return 0;
 }

--- a/src/bin/ufo-filterhelp.c.in
+++ b/src/bin/ufo-filterhelp.c.in
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2015 Karlsruhe Institute of Technology
+ *
+ * This file is part of ufo-filters.
+ *
+ * ufo-filters is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * ufo-filters is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with runjson.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <ufo/ufo.h>
+
+const gchar *filter_names = "@FILTER_LIST@";
+
+int
+main(int argc, char* argv[])
+{
+    GOptionContext *context;
+    GError *error = NULL;
+
+    static gboolean filters = FALSE;
+
+    static GOptionEntry entries[] = {
+        { "list-filters", 'l', 0, G_OPTION_ARG_NONE, &filters, "list all available filters", NULL },
+        { NULL }
+    };
+
+#if !(GLIB_CHECK_VERSION (2, 36, 0))
+    g_type_init ();
+#endif
+
+    context = g_option_context_new (NULL);
+    g_option_context_add_main_entries (context, entries, NULL);
+
+    if (!g_option_context_parse (context, &argc, &argv, &error)) {
+        g_print ("Error parsing options: %s\n", error->message);
+        return 1;
+    }
+    
+    if (argc == 1) {
+        if (filters) {
+            gchar **names = g_strsplit (filter_names, ";", -1);
+            if (!names) {
+                g_print ("No available filters could be found.\n");
+            }
+            else {
+                g_print ("The following tasks are available:\n");
+                guint i = 0; 
+                while (names[i]) {
+                    g_print ("%s\n", names[i]);
+                    i++;
+                }
+            }
+            g_strfreev (names);
+        }
+        else
+            g_print ("%s", g_option_context_get_help (context, TRUE, NULL));
+        
+        return 0;
+    }
+
+    return 0;
+}

--- a/src/bin/ufo-filterhelp.c.in
+++ b/src/bin/ufo-filterhelp.c.in
@@ -87,6 +87,8 @@ main(int argc, char* argv[])
                 g_print ("# Filter '%s' exposes the following properties\n", argv[i]);
                 g_print ("#\n");
                 for (guint j = 0; j < num_props; j++) {
+                    if (0 == g_strcmp0 (pspecs[j]->name, "num-processed"))
+                        continue;
                     g_print ("-- %s\n", pspecs[j]->name);
                     g_print ("Type: %s\n", g_type_name (pspecs[j]->value_type));
                     g_print ("Info: %s\n", g_param_spec_get_nick (pspecs[j]));


### PR DESCRIPTION
I was pretty overwhelmed by the amount of filters and the naming convention from `libufodetectedge.so` to `detect-edge` as the filter-names were very confusing to me, because of the removal of dashes and such. I know that a little bit of intelligence can help you guess where the dashes are supposed to go, but still there is cases where it is not quite obvious (like `ring-pattern` and `ringwriter`).

At first I used the `ufo_plugin_manager` to give me a list of know filters, but those ones are already stripped of the dashes in their names as well. So, I have whipped up a small CMAKE integrated script which generates a small `ufo-filterhelp` executable which gives you the correct naming conventions.  
Its just a quick idea, but maybe we can improve this to add _glib-ified_ listing of properties? 

For example:

```
$>ufo-filterhelp write
'write' filter exposes the following properties:
-- filename 
Type: String
Info: "Filename filename string"
Description: "filename string of the path and filename. If multiple files are written it must contain a '%i' specifier denoting the current count"  

-- append
Type: Boolean
Info: "If true the data is appended, otherwise overwritten"
Description: "If true the data is appended, otherwise overwritten"

-- bits 
Type: Unsigned Int
Info: "Number of bits per sample"
Description: "Number of bits per sample. Possible values in [8, 16, 32]."

$>
```

But, like I said, its just a quick idea. What do you think?
