### PR TITLE
Update StackTask filter: stack every [number] inputs

### DIFF
--- a/src/ufo-stack-task.c
+++ b/src/ufo-stack-task.c
@@ -108,16 +108,19 @@ ufo_stack_task_process (UfoTask *task,
 
     priv = UFO_STACK_TASK_GET_PRIVATE (task);
 
-    if (priv->current == priv->n_items) {
-        g_warning ("StackTask: current == max [%i == %i]", priv->current, priv->n_items);
-        return FALSE;
-    }
-
     size = ufo_buffer_get_size (inputs[0]);
     in_mem = (guint8 *) ufo_buffer_get_host_array (inputs[0], NULL);
     out_mem = (guint8 *) ufo_buffer_get_host_array (output, NULL);
     memcpy (out_mem + priv->current * size, in_mem, size);
     priv->current++;
+
+    if (priv->current == priv->n_items) {
+        // g_warning ("StackTask: stack full, ready for generating. [current %d]", priv->current);
+        priv->current = 0;
+        priv->generated = FALSE;
+        return FALSE;
+    }
+
     return TRUE;
 }
 


### PR DESCRIPTION
Modify StackTask to reflect the changes in the commit https://github.com/ufo-kit/ufo-core/commit/ce21698cdb187ed71cb3e23c70923fab9bccc6a2. 

It now stack ``number`` of inputs, pause to generate output and then continue stacking. ``number`` is a property of this filter. 
