### PR TITLE
fbp: Use number of projs to compute angle step

### DIFF
--- a/src/ufo-backproject-task.c
+++ b/src/ufo-backproject-task.c
@@ -216,7 +216,7 @@ ufo_backproject_task_get_requisition (UfoTask *task,
 
     if (priv->real_angle_step < 0.0) {
         if (priv->angle_step <= 0.0)
-            priv->real_angle_step = G_PI / ((gdouble) in_req.dims[1]);
+            priv->real_angle_step = G_PI / ((gdouble) priv->n_projections);
         else
             priv->real_angle_step = priv->angle_step;
     }


### PR DESCRIPTION
instead of the requisition dimensions because by the burst mode we get a
sinogram with less rows than the total number of projections.

Tiny change but it was quite annoying to have to set both the number of projections and angular step in case of burst mode.