### PR TITLE
Fix fbp

### DIFF
--- a/src/kernels/backproject.cl
+++ b/src/kernels/backproject.cl
@@ -72,6 +72,6 @@ backproject_tex (read_only image2d_t sinogram,
         sum += (isnan (val) ? 0.0 : val);
     }
 
-    slice[idy * width + idx] = sum * 4.0 * PI;
+    slice[idy * width + idx] = sum * PI / n_projections;
 }
 

--- a/src/ufo-filter-task.c
+++ b/src/ufo-filter-task.c
@@ -151,7 +151,7 @@ ufo_filter_task_setup (UfoTask *task,
 static void
 mirror_coefficients (gfloat *filter, guint width)
 {
-    for (guint k = width/2; k < width; k += 2) {
+    for (guint k = width/2 + 2; k < width; k += 2) {
         filter[k] = filter[width - k];
         filter[k + 1] = filter[width - k + 1];
     }
@@ -162,9 +162,12 @@ compute_ramp_coefficients (UfoFilterTaskPrivate *priv,
                            gfloat *filter,
                            guint width)
 {
-    const gdouble step = 1.0 / (width / 4.0);
+    const gdouble step = 2.0 / width;
 
-    for (guint k = 0; k < (width / 4) + 1; k++) {
+    filter[0] = 0.5 / width;
+    filter[1] = filter[0];
+
+    for (guint k = 1; k < width / 4 + 1; k++) {
         filter[2*k] = k * step * priv->scale;
         filter[2*k + 1] = filter[2*k];
     }


### PR DESCRIPTION
d5e097dc8e63635cdcd771db9c584ca8a5983fd6 doesn't do the job for me, what have you tested it on? Anyway, this PR gives me quantitatively correct results for shepp logan and also the new resolution pattern.

*Note*: I fixed the mirroring for ramp filter but didn't check yet the others, just not to forget.