### PR TITLE
Backproject titan

### DIFF
--- a/src/kernels/backproject.cl
+++ b/src/kernels/backproject.cl
@@ -67,6 +67,9 @@ backproject_tex (read_only image2d_t sinogram,
 #ifdef DEVICE_GEFORCE_GTX_TITAN_BLACK
 #pragma unroll 8
 #endif
+#ifdef DEVICE_GEFORCE_GTX_TITAN
+#pragma unroll 14
+#endif
     for(int proj = 0; proj < n_projections; proj++) {
         float h = by * sin_lut[angle_offset + proj] + bx * cos_lut[angle_offset + proj] + axis_pos;
         sum += read_imagef (sinogram, volumeSampler, (float2)(h, proj + 0.5f)).x;

--- a/src/kernels/backproject.cl
+++ b/src/kernels/backproject.cl
@@ -69,8 +69,7 @@ backproject_tex (read_only image2d_t sinogram,
 #endif
     for(int proj = 0; proj < n_projections; proj++) {
         float h = by * sin_lut[angle_offset + proj] + bx * cos_lut[angle_offset + proj] + axis_pos;
-        float val = read_imagef (sinogram, volumeSampler, (float2)(h, proj + 0.5f)).x;
-        sum += (isnan (val) ? 0.0 : val);
+        sum += read_imagef (sinogram, volumeSampler, (float2)(h, proj + 0.5f)).x;
     }
 
     slice[idy * get_global_size(0) + idx] = sum * M_PI / n_projections;

--- a/src/kernels/backproject.cl
+++ b/src/kernels/backproject.cl
@@ -21,8 +21,6 @@ constant sampler_t volumeSampler = CLK_NORMALIZED_COORDS_FALSE |
                                    CLK_ADDRESS_CLAMP |
                                    CLK_FILTER_LINEAR;
 
-#define PI 3.1415926535897932384626433832795028841971693993751058209749445923078164062f
-
 kernel void
 backproject_nearest (global float *sinogram,
                      global float *slice,
@@ -46,7 +44,7 @@ backproject_nearest (global float *sinogram,
         sum += sinogram[(int)(proj * width + h)];
     }
 
-    slice[idy * width + idx] = sum * PI / n_projections;
+    slice[idy * width + idx] = sum * M_PI / n_projections;
 }
 
 kernel void
@@ -75,6 +73,6 @@ backproject_tex (read_only image2d_t sinogram,
         sum += (isnan (val) ? 0.0 : val);
     }
 
-    slice[idy * get_global_size(0) + idx] = sum * PI / n_projections;
+    slice[idy * get_global_size(0) + idx] = sum * M_PI / n_projections;
 }
 


### PR DESCRIPTION
I squeezed out 20% performance increase from a GTX Titan. However, I need help from @matze because I can't find things like `DEVICE_GEFORCE_GTX_TITAN_BLACK` anywhere and that needs to be done properly here.
BTW we should start thinking about some micro-optimizations for particular architectures, i.e. work group sizes, number of projections processed at the same time by laminography, loop unrolling like the one here and many more. In the best case the make system will determine the architecture and concrete devices and do the thing. Otherwise we could use a bunch of flags or maybe some customization tool, if it exists for such a project.