### PR TITLE
Adds Bitdepth to memory-in generator

### DIFF
--- a/src/ufo-memory-in-task.c
+++ b/src/ufo-memory-in-task.c
@@ -118,13 +118,11 @@ ufo_memory_in_task_generate (UfoTask *task,
     /* FIXME: user should have the possibility of copying instead of setting */
     //ufo_buffer_set_host_array (output, &priv->pointer[priv->read * priv->width * priv->height], FALSE);
 
-	// Changes from Raphael Pour
 	float *data = ufo_buffer_get_host_array(output,NULL);
 	memcpy((guint8*)data, &priv->pointer[priv->read * priv->width * priv->height], priv->width * priv->height * priv->bytes_per_pixel );
 
 	if(priv->bitdepth != UFO_BUFFER_DEPTH_32F)
 		ufo_buffer_convert(output, priv->bitdepth);
-	// End Changes from Raphael Pour
 
     priv->read++;
 

--- a/src/ufo-memory-in-task.h
+++ b/src/ufo-memory-in-task.h
@@ -21,7 +21,7 @@
 #define __UFO_MEMORY_IN_TASK_H
 
 #include <ufo/ufo.h>
-
+#include <string.h>
 G_BEGIN_DECLS
 
 #define UFO_TYPE_MEMORY_IN_TASK             (ufo_memory_in_task_get_type())


### PR DESCRIPTION
In order to handover data to UFO which are not consisting of 32-Bit floats, the incoming data will be converted depending on the set bit depth.
This is analog to filters like stdin-reader.