### PR TITLE
Fix #159: add boolean `rescale` option

### DIFF
--- a/docs/sinks.rst
+++ b/docs/sinks.rst
@@ -45,7 +45,8 @@ File writer
         Possible values are 8 and 16 which are saved as integer types and 32 bit
         float. By default, the minimum and maximum for scaling is determined
         automatically, however depending on the use case you should override
-        this with the ``minimum`` and ``maximum`` properties.
+        this with the ``minimum`` and ``maximum`` properties. To avoid
+        rescaling, set the ``rescale`` property to ``FALSE``.
 
     .. gobj:prop:: minimum:float
 
@@ -56,6 +57,12 @@ File writer
 
         This value will represent the largest possible value for discrete bit
         depths, i.e. 8 and 16 bit.
+
+    .. gobj:prop:: rescale:boolean
+
+        If ``TRUE`` and ``bits`` is set to a value less than 32, rescale values
+        either by looking for minimum and maximum values or using the values
+        provided by the user.
 
     For JPEG files the following property applies:
 

--- a/src/ufo-write-task.c
+++ b/src/ufo-write-task.c
@@ -58,6 +58,7 @@ struct _UfoWriteTaskPrivate {
     UfoBufferDepth depth;
     gfloat minimum;
     gfloat maximum;
+    gboolean rescale;
 
     gboolean multi_file;
     gboolean opened;
@@ -100,6 +101,7 @@ enum {
     PROP_BITS,
     PROP_MINIMUM,
     PROP_MAXIMUM,
+    PROP_RESCALE,
 #ifdef HAVE_JPEG
     PROP_JPEG_QUALITY,
 #endif
@@ -340,6 +342,7 @@ ufo_write_task_process (UfoTask *task,
     image.depth = priv->depth;
     image.min = priv->minimum;
     image.max = priv->maximum;
+    image.rescale = priv->rescale;
 
     for (guint i = 0; i < num_frames; i++) {
 retry:
@@ -420,6 +423,9 @@ ufo_write_task_set_property (GObject *object,
             break;
         case PROP_MINIMUM:
             priv->minimum = g_value_get_float (value);
+            break;
+        case PROP_RESCALE:
+            priv->rescale = g_value_get_boolean (value);
             break;
 #ifdef HAVE_JPEG
         case PROP_JPEG_QUALITY:
@@ -606,6 +612,13 @@ ufo_write_task_class_init (UfoWriteTaskClass *klass)
             -G_MAXFLOAT, G_MAXFLOAT, -G_MAXFLOAT,
             G_PARAM_READWRITE);
 
+    properties[PROP_RESCALE] =
+        g_param_spec_boolean ("rescale",
+            "If true rescale values automatically or according to set min and max",
+            "If true rescale values automatically or according to set min and max",
+            TRUE,
+            G_PARAM_READWRITE);
+
 #ifdef HAVE_JPEG
     properties[PROP_JPEG_QUALITY] =
         g_param_spec_uint ("jpeg-quality",
@@ -632,6 +645,7 @@ ufo_write_task_init(UfoWriteTask *self)
     self->priv->depth = UFO_BUFFER_DEPTH_32F;
     self->priv->minimum = G_MAXFLOAT;
     self->priv->maximum = -G_MAXFLOAT;
+    self->priv->rescale = TRUE;
     self->priv->writer = NULL;
     self->priv->opened = FALSE;
     self->priv->filename = NULL;

--- a/src/writers/ufo-writer.h
+++ b/src/writers/ufo-writer.h
@@ -39,6 +39,7 @@ typedef struct {
     UfoBufferDepth depth;
     gfloat min;
     gfloat max;
+    gboolean rescale;
 } UfoWriterImage;
 
 struct _UfoWriterIface {


### PR DESCRIPTION
If set to `TRUE` (default) the writer will rescale the values either implicitly according to the minimum and maximum values or the ones provided by the user. Otherwise the data will not be modified numerically.

@tfarago: I couldn't find any prove that there was no rescaling before. It was in there already for quite a while which is why I choose a default value of `TRUE`, i.e. you have to opt-out. If you are okay, I will merge it.