### PR TITLE
tests: Use required : false in find_program

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,7 +6,7 @@ tests = [
     'test-file-write-regression'
 ]
 
-tiffinfo = find_program('tiffinfo')
+tiffinfo = find_program('tiffinfo', required : false)
 
 if tiffinfo.found()
     tests += ['test-142']


### PR DESCRIPTION
I'm guessing this slipped because you have the program.