### PR TITLE
sphinx: Fix Directive import to work with Sphinx 1.8

### DIFF
--- a/docs/sphinxgobject/domain.py
+++ b/docs/sphinxgobject/domain.py
@@ -1,7 +1,8 @@
 from docutils import nodes
+from docutils.parsers.rst import Directive
 from sphinx import addnodes
 from sphinx.domains import Domain, ObjType
-from sphinx.directives import ObjectDescription, Directive
+from sphinx.directives import ObjectDescription
 from sphinx.locale import l_
 from sphinx.roles import XRefRole
 from sphinx.util.docfields import Field


### PR DESCRIPTION
Since sphinx-doc/sphinx@6c08963f25c0834eab7d31543810c82f4e09daf5, `sphinx.directives` module no longer has `Directive` class imported.

So this class should be imported directly from `docutils.parsers.rst` module.