### PR TITLE
fix CMake for zmq

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -152,7 +152,7 @@ pkg_check_modules(CLBLAST clblast)
 pkg_check_modules(PANGOCAIRO pangocairo)
 pkg_check_modules(OPENCV opencv)
 pkg_check_modules(ZMQ libzmq)
-pkg_check_modules(JSON_GLIB lib-json-glib-1.0>=1.1.0)
+pkg_check_modules(JSON_GLIB json-glib-1.0)
 
 
 if (OPENMP_FOUND)
@@ -274,6 +274,7 @@ if (ZMQ_FOUND AND JSON_GLIB_FOUND)
     link_directories(${ZMQ_LIBRARY_DIRS} ${JSON_GLIB_LIBRARY_DIRS})
     list(APPEND ufofilter_SRCS ufo-zmq-pub-task.c ufo-zmq-sub-task.c)
     list(APPEND zmq_pub_aux_LIBS ${ZMQ_LIBRARIES} ${JSON_GLIB_LIBRARIES})
+    list(APPEND zmq_sub_aux_LIBS ${ZMQ_LIBRARIES} ${JSON_GLIB_LIBRARIES})
 endif ()
 #}}}
 #{{{ Plugin targets


### PR DESCRIPTION
This fixes the CMake file to correctly build the zmq-sub and zmq-pub filter.