### PR TITLE
Fix properties of transpose task

### DIFF
--- a/src/ufo-transpose-task.c
+++ b/src/ufo-transpose-task.c
@@ -175,6 +175,7 @@ ufo_transpose_task_class_init (UfoTransposeTaskClass *klass)
     GObjectClass *oclass = G_OBJECT_CLASS (klass);
 
     oclass->finalize = ufo_transpose_task_finalize;
+    g_type_class_add_private (oclass, sizeof(UfoTransposeTaskPrivate));
 }
 
 static void

--- a/src/ufo-transpose-task.h
+++ b/src/ufo-transpose-task.h
@@ -54,6 +54,7 @@ struct _UfoTransposeTask {
 struct _UfoTransposeTaskClass {
     /*< private >*/
     UfoTaskNodeClass parent_class;
+  UfoTransposeTaskPrivate *priv;
 };
 
 UfoNode  *ufo_transpose_task_new       (void);


### PR DESCRIPTION
This fixes a crash when the transpose task was asked for its properties e.g.:
`ufo-query -p transpose`