### PR TITLE
stack: force nonfactor generation

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -751,7 +751,9 @@ Stacking
 .. gobj:class:: stack
 
     Symmetrical to the slice filter, the stack filter stacks two-dimensional
-    input.
+    input. If ``number`` is not a divisor of the number of input images, the
+    last produced stack at index which starts to exceed the number of input
+    images will contain arbitrary images from the previous iterations.
 
     .. gobj:prop:: number:uint
 


### PR DESCRIPTION
If the number of images in the stack hadn't been a divisor of the number
of input images, the last images would have been dropped. This makes
sure all images are processed and fills the last positions of the stack
(when the total number of stacked images starts to exceed the number of
input images) with arbitrary previous images. Fixes #210.