### PR TITLE
chore: Update python dependency for meson

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -235,7 +235,7 @@ endif
 
 # lamino plugin
 
-python = find_program('python', required: false)
+python = find_program('python3', required: false)
 
 if python.found()
     shared_module('lamino-backproject',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -49,7 +49,7 @@ foreach t: python_tests
     configure_file(input: filename,
                    output: filename,
                    copy: true)
-    test(t, find_program('python'),
+    test(t, find_program('python3'),
          args: join_paths(meson.current_build_dir(), filename),
          env: test_env)
 endforeach


### PR DESCRIPTION
**Premise**: On Ubuntu 22.04 onward it might be helpful to explicitly specify python3 as the dependency for meson find_program to avoid ambiguity.