### PR TITLE
backproject: Add cubic interpolation

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -1206,7 +1206,7 @@ Tomographic backprojection
 
     .. gobj:prop:: mode:enum
 
-        Reconstruction mode which can be either ``nearest`` or ``texture``.
+        Reconstruction mode which can be ``nearest``, ``texture`` or ``cubic``.
 
     .. gobj:prop:: roi-x:uint
 

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -1228,7 +1228,7 @@ Tomographic backprojection
 
     .. gobj:prop:: mode:enum
 
-        Reconstruction mode which can be either ``nearest`` or ``texture``.
+        Reconstruction mode which can be ``nearest``, ``texture`` or ``cubic``.
 
     .. gobj:prop:: roi-x:uint
 

--- a/src/kernels/backproject.cl
+++ b/src/kernels/backproject.cl
@@ -150,8 +150,8 @@ backproject_cubic_naive (global float *sinogram,
 }
 
 kernel void
-backproject_linear (global float *sinogram,
-                    global float *slice,
+backproject_linear (global float4 *sinogram,
+                    global float4 *slice,
                     constant float *sin_lut,
                     constant float *cos_lut,
                     const unsigned int x_offset,
@@ -172,10 +172,10 @@ backproject_linear (global float *sinogram,
     int group_width = get_local_size (0);
     float bx = idx - axis_pos + x_offset + 0.5f;
     float by, cos_angle, sin_angle;
-    float sum[PIXELS_PER_THREAD];
+    float4 sum[PIXELS_PER_THREAD];
     float xif, xf, tmp;
     int xi, xi_last, j_stop;
-    float sino_local[2];
+    float4 sino_local[2];
 
     if (idx >= width) {
         return;
@@ -184,7 +184,7 @@ backproject_linear (global float *sinogram,
     j_stop = min (PIXELS_PER_THREAD, height - gy * PIXELS_PER_THREAD);
 
     for (int j = 0; j < j_stop; j++) {
-        sum[j] = 0.0f;
+        sum[j] = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
     }
 
     for (int proj = 0; proj < n_projections; proj++) {
@@ -233,8 +233,8 @@ backproject_linear (global float *sinogram,
 }
 
 kernel void
-backproject_cubic (global float *sinogram,
-                   global float *slice,
+backproject_cubic (global float4 *sinogram,
+                   global float4 *slice,
                    constant float *sin_lut,
                    constant float *cos_lut,
                    const unsigned int x_offset,
@@ -255,11 +255,11 @@ backproject_cubic (global float *sinogram,
     int group_width = get_local_size (0);
     float bx = idx - axis_pos + x_offset + 0.5f;
     float by, cos_angle, sin_angle;
-    float sum[PIXELS_PER_THREAD];
+    float4 sum[PIXELS_PER_THREAD];
     float xif, xf, tmp;
     int xi, xi_last, j_stop;
-    float d_1, d_2;
-    float sino_local[4];
+    float4 d_1, d_2;
+    float4 sino_local[4];
 
     if (idx >= width) {
         return;
@@ -268,7 +268,7 @@ backproject_cubic (global float *sinogram,
     j_stop = min (PIXELS_PER_THREAD, height - gy * PIXELS_PER_THREAD);
 
     for (int j = 0; j < j_stop; j++) {
-        sum[j] = 0.0f;
+        sum[j] = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
     }
 
     for (int proj = 0; proj < n_projections; proj++) {
@@ -330,4 +330,24 @@ backproject_cubic (global float *sinogram,
         idy = gy * PIXELS_PER_THREAD + j;
         slice[idy * width + idx] = sum[j] * M_PI_F / n_projections;
     }
+}
+
+kernel void
+interleave (global float *sinogram,
+            global float *stack,
+            int offset)
+{
+    const int idx = get_global_id(0);
+
+    stack[4 * idx + offset] = sinogram[idx];
+}
+
+kernel void
+uninterleave (global float *slice,
+              global float *stack,
+              int offset)
+{
+    const int idx = get_global_id(0);
+
+    slice[idx] = stack[4 * idx + offset];
 }

--- a/src/kernels/backproject.cl
+++ b/src/kernels/backproject.cl
@@ -17,6 +17,8 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define PIXELS_PER_THREAD 8
+
 constant sampler_t volumeSampler = CLK_NORMALIZED_COORDS_FALSE |
                                    CLK_ADDRESS_CLAMP |
                                    CLK_FILTER_LINEAR;
@@ -93,12 +95,141 @@ backproject_tex (read_only image2d_t sinogram,
     slice[idy * get_global_size(0) + idx] = sum * M_PI_F / n_projections;
 }
 
-inline float get_sino_point(global float *sino, int x, int y, int width, int height)
+inline float get_sino_point (global float *sino, int x, int y, int width, int height)
 {
     x = clamp (x, 0, width - 1);
     y = clamp (y, 0, height - 1);
 
     return sino[y * width + x];
+}
+
+/* *backproject_cubic* is an optimized version of this kernel, which is easy to
+ * understand and can be used for correctness testing */
+kernel void
+backproject_cubic_naive (global float *sinogram,
+                         global float *slice,
+                         constant float *sin_lut,
+                         constant float *cos_lut,
+                         const unsigned int x_offset,
+                         const unsigned int y_offset,
+                         const unsigned int angle_offset,
+                         const unsigned n_projections,
+                         const float axis_pos,
+                         const int sino_width)
+{
+    int idx = get_global_id(0);
+    int idy = get_global_id(1);
+    int width = get_global_size(0);
+    int height = get_global_size(1);
+    float bx = idx - axis_pos + x_offset + 0.5f;
+    float by = idy - axis_pos + y_offset + 0.5f;
+    float sum = 0.0f;
+    float4 A_0 = (float4)( 2.0f, -2.0f,  1.0f,  1.0f);
+    float4 A_1 = (float4)(-3.0f,  3.0f, -2.0f, -1.0f);
+    float4 A_2 = (float4)( 0.0f,  0.0f,  1.0f,  0.0f);
+    float4 A_3 = (float4)( 1.0f,  0.0f,  0.0f,  0.0f);
+    float xif, xf, tmp;
+    int xi;
+    float4 data;
+
+
+    for (int proj = 0; proj < n_projections; proj++) {
+        float h = axis_pos + bx * cos_lut[angle_offset + proj] + by * sin_lut[angle_offset + proj] - 0.5f;
+        xf = modf (h, &xif);
+        xi = (int) xif;
+        tmp    = get_sino_point (sinogram, xi - 1, proj, sino_width, height);
+        data.x = get_sino_point (sinogram,     xi, proj, sino_width, height);
+        data.y = get_sino_point (sinogram, xi + 1, proj, sino_width, height);
+        data.z = get_sino_point (sinogram, xi + 2, proj, sino_width, height);
+        data.w = data.z - data.x;
+        data.z = data.y - tmp;
+        sum += dot (A_0, data) * xf * xf * xf + dot (A_1, data) * xf * xf + dot (A_2, data) * xf + dot(A_3, data);
+    }
+
+    slice[idy * width + idx] = sum * M_PI_F / n_projections;
+}
+
+kernel void
+backproject_linear (global float *sinogram,
+                    global float *slice,
+                    constant float *sin_lut,
+                    constant float *cos_lut,
+                    const unsigned int x_offset,
+                    const unsigned int y_offset,
+                    const unsigned int angle_offset,
+                    const unsigned n_projections,
+                    const float axis_pos,
+                    const int width,
+                    const int height,
+                    const int sino_width,
+                    const int between_0_180)
+{
+    int idx = get_global_id(0);
+    int idy;
+    int lx = get_local_id (0);
+    int gx = get_group_id (0);
+    int gy = get_group_id (1);
+    int group_width = get_local_size (0);
+    float bx = idx - axis_pos + x_offset + 0.5f;
+    float by, cos_angle, sin_angle;
+    float sum[PIXELS_PER_THREAD];
+    float xif, xf, tmp;
+    int xi, xi_last, j_stop;
+    float sino_local[2];
+
+    if (idx >= width) {
+        return;
+    }
+
+    j_stop = min (PIXELS_PER_THREAD, height - gy * PIXELS_PER_THREAD);
+
+    for (int j = 0; j < j_stop; j++) {
+        sum[j] = 0.0f;
+    }
+
+    for (int proj = 0; proj < n_projections; proj++) {
+        cos_angle = cos_lut[angle_offset + proj];
+        sin_angle = sin_lut[angle_offset + proj];
+        tmp = axis_pos + bx * cos_angle - 0.5f;
+
+        for (int j = 0; j < j_stop; j++) {
+            idy = gy * PIXELS_PER_THREAD + j;
+            by = idy - axis_pos + y_offset + 0.5f;
+            xf = modf (tmp + by * sin_angle, &xif);
+            xi = (int) xif;
+
+            if (j == 0) {
+                /* Initialization: load four neighbors and compute central
+                 * difference derivatives. */
+                xi_last = xi;
+                sino_local[0] = sinogram[proj * sino_width + clamp (xi    , 0, sino_width - 1)];
+                sino_local[1] = sinogram[proj * sino_width + clamp (xi + 1, 0, sino_width - 1)];
+            }
+            if (xi > xi_last) {
+                /* Difference to the pixel below can be at most 1 when angle is
+                 * 90 degrees, otherwise it is definitely less than one. This is
+                 * the case when shift is positive, so we replace the right
+                 * pixel. We shift all pixels and load a new one, this is way
+                 * faster than ring buffer rotation. */
+                sino_local[0] = sino_local[1];
+                sino_local[1] = sinogram[proj * sino_width + clamp (xi + 1, 0, sino_width - 1)];
+            }
+            if (!between_0_180 && xi < xi_last) {
+                /* This is for angles between 180 - 360 degrees, where the shift
+                 * is negative. We replace the left pixel. */
+                sino_local[1] = sino_local[0];
+                sino_local[0] = sinogram[proj * sino_width + clamp (xi, 0, sino_width - 1)];
+            }
+
+            sum[j] += sino_local[0] * (1.0f - xf) + sino_local[1] * xf;
+            xi_last = xi;
+        }
+    }
+
+    for (int j = 0; j < j_stop; j++) {
+        idy = gy * PIXELS_PER_THREAD + j;
+        slice[idy * width + idx] = sum[j] * M_PI_F / n_projections;
+    }
 }
 
 kernel void
@@ -110,35 +241,93 @@ backproject_cubic (global float *sinogram,
                    const unsigned int y_offset,
                    const unsigned int angle_offset,
                    const unsigned n_projections,
-                   const float axis_pos)
+                   const float axis_pos,
+                   const int width,
+                   const int height,
+                   const int sino_width,
+                   const int between_0_180)
 {
-    const int idx = get_global_id(0);
-    const int idy = get_global_id(1);
-    const int width = get_global_size(0);
-    const int height = get_global_size(1);
-    const float bx = idx - axis_pos + x_offset + 0.5f;
-    const float by = idy - axis_pos + y_offset + 0.5f;
-    float sum = 0.0f;
-    float4 A_0 = (float4)( 2.0f, -2.0f,  1.0f,  1.0f);
-    float4 A_1 = (float4)(-3.0f,  3.0f, -2.0f, -1.0f);
-    float4 A_2 = (float4)( 0.0f,  0.0f,  1.0f,  0.0f);
-    float4 A_3 = (float4)( 1.0f,  0.0f,  0.0f,  0.0f);
+    int idx = get_global_id(0);
+    int idy;
+    int lx = get_local_id (0);
+    int gx = get_group_id (0);
+    int gy = get_group_id (1);
+    int group_width = get_local_size (0);
+    float bx = idx - axis_pos + x_offset + 0.5f;
+    float by, cos_angle, sin_angle;
+    float sum[PIXELS_PER_THREAD];
     float xif, xf, tmp;
-    int xi;
-    float4 data;
+    int xi, xi_last, j_stop;
+    float d_1, d_2;
+    float sino_local[4];
 
-    for(int proj = 0; proj < n_projections; proj++) {
-        float h = axis_pos + bx * cos_lut[angle_offset + proj] + by * sin_lut[angle_offset + proj] - 0.5f;
-        xf = modf (h, &xif);
-        xi = (int) xif;
-        tmp    = get_sino_point (sinogram, xi - 1, proj, width, height);
-        data.x = get_sino_point (sinogram,     xi, proj, width, height);
-        data.y = get_sino_point (sinogram, xi + 1, proj, width, height);
-        data.z = get_sino_point (sinogram, xi + 2, proj, width, height);
-        data.w = data.z - data.x;
-        data.z = data.y - tmp;
-        sum += dot (A_0, data) * xf * xf * xf + dot (A_1, data) * xf * xf + dot (A_2, data) * xf + dot(A_3, data);
+    if (idx >= width) {
+        return;
     }
 
-    slice[idy * width + idx] = sum * M_PI_F / n_projections;
+    j_stop = min (PIXELS_PER_THREAD, height - gy * PIXELS_PER_THREAD);
+
+    for (int j = 0; j < j_stop; j++) {
+        sum[j] = 0.0f;
+    }
+
+    for (int proj = 0; proj < n_projections; proj++) {
+        cos_angle = cos_lut[proj];
+        sin_angle = sin_lut[proj];
+        tmp = axis_pos + bx * cos_angle - 0.5f;
+
+        for (int j = 0; j < j_stop; j++) {
+            idy = gy * PIXELS_PER_THREAD + j;
+            by = idy - axis_pos + y_offset + 0.5f;
+            xf = modf (tmp + by * sin_angle, &xif);
+            xi = (int) xif;
+
+            if (j == 0) {
+                /* Initialization: load four neighbors and compute central
+                 * difference derivatives. */
+                xi_last = xi;
+                for (int i = 0; i < 4; i++) {
+                    sino_local[i] = sinogram[proj * sino_width + clamp (xi - 1 + i, 0, sino_width - 1)];
+                }
+                d_1 = sino_local[2] - sino_local[0];
+                d_2 = sino_local[3] - sino_local[1];
+            }
+            if (xi > xi_last) {
+                /* Difference to the pixel below can be at most 1 when angle is
+                 * 90 degrees, otherwise it is definitely less than one. This is
+                 * the case when shift is positive, so we replace the right
+                 * pixel. We shift all pixels and load a new one, this is way
+                 * faster than ring buffer rotation. */
+                sino_local[0] = sino_local[1];
+                sino_local[1] = sino_local[2];
+                sino_local[2] = sino_local[3];
+                sino_local[3] = sinogram[proj * sino_width + clamp (xi + 2, 0, sino_width - 1)];
+                /* Recalculate derivatives */
+                d_1 = sino_local[2] - sino_local[0];
+                d_2 = sino_local[3] - sino_local[1];
+            }
+            if (!between_0_180 && xi < xi_last) {
+                /* This is for angles between 180 - 360 degrees, where the shift
+                 * is negative. */
+                sino_local[3] = sino_local[2];
+                sino_local[2] = sino_local[1];
+                sino_local[1] = sino_local[0];
+                sino_local[0] = sinogram[proj * sino_width + clamp (xi - 1, 0, sino_width - 1)];
+                /* Recalculate derivatives */
+                d_1 = sino_local[2] - sino_local[0];
+                d_2 = sino_local[3] - sino_local[1];
+            }
+
+            sum[j] +=
+                xf * xf * xf * (2 * (sino_local[1] - sino_local[2]) + d_1 + d_2)
+                + xf * xf * (3 * (sino_local[2] - sino_local[1]) - 2 * d_1 - d_2)
+                + xf * d_1 + sino_local[1];
+            xi_last = xi;
+        }
+    }
+
+    for (int j = 0; j < j_stop; j++) {
+        idy = gy * PIXELS_PER_THREAD + j;
+        slice[idy * width + idx] = sum[j] * M_PI_F / n_projections;
+    }
 }

--- a/src/kernels/backproject.cl
+++ b/src/kernels/backproject.cl
@@ -93,3 +93,52 @@ backproject_tex (read_only image2d_t sinogram,
     slice[idy * get_global_size(0) + idx] = sum * M_PI_F / n_projections;
 }
 
+inline float get_sino_point(global float *sino, int x, int y, int width, int height)
+{
+    x = clamp (x, 0, width - 1);
+    y = clamp (y, 0, height - 1);
+
+    return sino[y * width + x];
+}
+
+kernel void
+backproject_cubic (global float *sinogram,
+                   global float *slice,
+                   constant float *sin_lut,
+                   constant float *cos_lut,
+                   const unsigned int x_offset,
+                   const unsigned int y_offset,
+                   const unsigned int angle_offset,
+                   const unsigned n_projections,
+                   const float axis_pos)
+{
+    const int idx = get_global_id(0);
+    const int idy = get_global_id(1);
+    const int width = get_global_size(0);
+    const int height = get_global_size(1);
+    const float bx = idx - axis_pos + x_offset + 0.5f;
+    const float by = idy - axis_pos + y_offset + 0.5f;
+    float sum = 0.0f;
+    float4 A_0 = (float4)( 2.0f, -2.0f,  1.0f,  1.0f);
+    float4 A_1 = (float4)(-3.0f,  3.0f, -2.0f, -1.0f);
+    float4 A_2 = (float4)( 0.0f,  0.0f,  1.0f,  0.0f);
+    float4 A_3 = (float4)( 1.0f,  0.0f,  0.0f,  0.0f);
+    float xif, xf, tmp;
+    int xi;
+    float4 data;
+
+    for(int proj = 0; proj < n_projections; proj++) {
+        float h = axis_pos + bx * cos_lut[angle_offset + proj] + by * sin_lut[angle_offset + proj] - 0.5f;
+        xf = modf (h, &xif);
+        xi = (int) xif;
+        tmp    = get_sino_point (sinogram, xi - 1, proj, width, height);
+        data.x = get_sino_point (sinogram,     xi, proj, width, height);
+        data.y = get_sino_point (sinogram, xi + 1, proj, width, height);
+        data.z = get_sino_point (sinogram, xi + 2, proj, width, height);
+        data.w = data.z - data.x;
+        data.z = data.y - tmp;
+        sum += dot (A_0, data) * xf * xf * xf + dot (A_1, data) * xf * xf + dot (A_2, data) * xf + dot(A_3, data);
+    }
+
+    slice[idy * width + idx] = sum * M_PI_F / n_projections;
+}

--- a/src/kernels/backproject.cl
+++ b/src/kernels/backproject.cl
@@ -17,7 +17,7 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define PIXELS_PER_THREAD 8
+#define PIXELS_PER_THREAD 16
 
 constant sampler_t volumeSampler = CLK_NORMALIZED_COORDS_FALSE |
                                    CLK_ADDRESS_CLAMP |

--- a/src/ufo-backproject-task.c
+++ b/src/ufo-backproject-task.c
@@ -48,11 +48,13 @@ static GEnumValue mode_values[] = {
 struct _UfoBackprojectTaskPrivate {
     cl_context context;
     cl_kernel kernels[NUM_MODES];
+    cl_kernel interleave_kernel, uninterleave_kernel;
     cl_mem sin_lut;
     cl_mem cos_lut;
+    cl_mem sino_stack_mem, slice_stack_mem;
     gfloat *host_sin_lut;
     gfloat *host_cos_lut;
-    gdouble axis_pos;
+    gfloat axis_pos;
     gdouble angle_step;
     gdouble angle_offset;
     gdouble real_angle_step;
@@ -64,6 +66,9 @@ struct _UfoBackprojectTaskPrivate {
     guint roi_y;
     gint roi_width;
     gint roi_height;
+    gint pack, num_packed, current;
+    gint sino_width;
+    gboolean inputs_stopped;
     Mode mode;
 };
 
@@ -98,6 +103,68 @@ ufo_backproject_task_new (void)
     return UFO_NODE (g_object_new (UFO_TYPE_BACKPROJECT_TASK, NULL));
 }
 
+static void
+backproject_new (UfoTask *task, UfoRequisition *requisition)
+{
+    UfoBackprojectTaskPrivate *priv;
+    UfoGpuNode *node;
+    UfoProfiler *profiler;
+    cl_command_queue cmd_queue;
+    cl_kernel kernel;
+    cl_int width, height;
+    cl_int between_0_180 = 1;
+    guint num_processed;
+    GValue *work_group_size_gvalue;
+    /* TODO downsize like in transpose until GPU max work group size is satisfied */
+    gsize local_size[2], global_size[2];
+
+    priv = UFO_BACKPROJECT_TASK_GET_PRIVATE (task);
+    node = UFO_GPU_NODE (ufo_task_node_get_proc_node (UFO_TASK_NODE (task)));
+    cmd_queue = ufo_gpu_node_get_cmd_queue (node);
+    profiler = ufo_task_node_get_profiler (UFO_TASK_NODE (task));
+    kernel = priv->kernels[priv->mode];
+
+    /* We get better performance if we do not need to check for left shift
+     * in the kernels, so figure this out here and make a global flag */
+    if (priv->angle_offset < 0.0 || priv->angle_offset > M_PI
+        || priv->angle_offset + (priv->n_projections - 1) * priv->real_angle_step < 0.0
+        || priv->angle_offset + (priv->n_projections - 1) * priv->real_angle_step > M_PI) {
+        between_0_180 = 0;
+    }
+    work_group_size_gvalue = ufo_gpu_node_get_info (node, UFO_GPU_NODE_INFO_MAX_WORK_GROUP_SIZE);
+    /* Use maximum possible work group size as width and height one */
+    local_size[0] = g_value_get_ulong (work_group_size_gvalue) / priv->pack;
+    local_size[1] = 1;
+    g_value_unset (work_group_size_gvalue);
+    global_size[0] = ((requisition->dims[0] - 1) / local_size[0] + 1) * local_size[0];
+    /* Global size has PIXELS_PER_THREAD less rows because one thread
+     * processes PIXELS_PER_THREAD rows */
+    global_size[1] = ((requisition->dims[1] - 1) / PIXELS_PER_THREAD + 1);
+    width = (cl_int) requisition->dims[0];
+    height = (cl_int) requisition->dims[1];
+    g_object_get (task, "num_processed", &num_processed, NULL);
+    if (num_processed == priv->pack - 1) {
+        g_debug ("backproject: angles between 0 - 180: %d", between_0_180);
+        g_debug ("backproject: global size: %lu %lu, local size: %lu %lu, sino width and height: %d %u",
+                 global_size[0], global_size[1], local_size[0], local_size[1], priv->sino_width, priv->burst_projections);
+    }
+
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 0, sizeof (cl_mem), &priv->sino_stack_mem));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 1, sizeof (cl_mem), &priv->slice_stack_mem));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 2, sizeof (cl_mem), &priv->sin_lut));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 3, sizeof (cl_mem), &priv->cos_lut));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 4, sizeof (guint),  &priv->roi_x));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 5, sizeof (guint),  &priv->roi_y));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 6, sizeof (guint),  &priv->offset));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 7, sizeof (guint),  &priv->burst_projections));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 8, sizeof (gfloat), &priv->axis_pos));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 9, sizeof (cl_int), &width));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 10, sizeof (cl_int), &height));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 11, sizeof (cl_int), &priv->sino_width));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 12, sizeof (cl_int), &between_0_180));
+    ufo_profiler_call (profiler, cmd_queue, kernel, 2, global_size, local_size);
+}
+
 static gboolean
 ufo_backproject_task_process (UfoTask *task,
                               UfoBuffer **inputs,
@@ -112,21 +179,14 @@ ufo_backproject_task_process (UfoTask *task,
     cl_mem in_mem;
     cl_mem out_mem;
     cl_kernel kernel;
-    cl_int sino_width, width, height;
-    cl_int between_0_180 = 1;
-    guint num_processed;
-    gfloat axis_pos;
-    GValue *work_group_size_gvalue;
-    /* TODO downsize like in transpose until GPU max work group size is satisfied */
-    gsize local_size[2], global_size[2];
+    gsize sinogram_size;
 
     priv = UFO_BACKPROJECT_TASK (task)->priv;
     node = UFO_GPU_NODE (ufo_task_node_get_proc_node (UFO_TASK_NODE (task)));
     cmd_queue = ufo_gpu_node_get_cmd_queue (node);
     out_mem = ufo_buffer_get_device_array (output, cmd_queue);
     ufo_buffer_get_requisition (inputs[0], &in_req);
-
-    kernel = priv->kernels[priv->mode];
+    profiler = ufo_task_node_get_profiler (UFO_TASK_NODE (task));
 
     /* We need an image if mode is texture, otherwise just the array */
     if (priv->mode == MODE_TEXTURE) {
@@ -136,67 +196,96 @@ ufo_backproject_task_process (UfoTask *task,
     }
 
     if (priv->mode == MODE_LINEAR || priv->mode == MODE_CUBIC) {
-        /* We get better performance if we do not need to check for left shift
-         * in the kernels, so figure this out here and make a global flag */
-        if (priv->angle_offset < 0.0 || priv->angle_offset > M_PI
-            || priv->angle_offset + (priv->n_projections - 1) * priv->real_angle_step < 0.0
-            || priv->angle_offset + (priv->n_projections - 1) * priv->real_angle_step > M_PI) {
-            between_0_180 = 0;
-        }
-        in_mem = ufo_buffer_get_device_array (inputs[0], cmd_queue);
-        work_group_size_gvalue = ufo_gpu_node_get_info (node, UFO_GPU_NODE_INFO_MAX_WORK_GROUP_SIZE);
-        /* Use maximum possible work group size as width and height one */
-        local_size[0] = g_value_get_ulong (work_group_size_gvalue);
-        local_size[1] = 1;
-        g_value_unset (work_group_size_gvalue);
-        global_size[0] = ((requisition->dims[0] - 1) / local_size[0] + 1) * local_size[0];
-        /* Global size has PIXELS_PER_THREAD less rows because one thread
-         * processes PIXELS_PER_THREAD rows */
-        global_size[1] = ((requisition->dims[1] - 1) / PIXELS_PER_THREAD + 1);
-        width = (cl_int) requisition->dims[0];
-        height = (cl_int) requisition->dims[1];
-        sino_width = (cl_int) in_req.dims[0];
-        g_object_get (task, "num_processed", &num_processed, NULL);
-        if (num_processed == 0) {
-            g_debug ("backproject: angles between 0 - 180: %d", between_0_180);
-            g_debug ("backproject: global size: %lu %lu, local size: %lu %lu, sino width and height: %d %u",
-                     global_size[0], global_size[1], local_size[0], local_size[1], sino_width, priv->burst_projections);
-        }
-    }
-
-    /* Guess axis position if they are not provided by the user. */
-    if (priv->axis_pos <= 0.0) {
-        axis_pos = (gfloat) ((gfloat) in_req.dims[0]) / 2.0f;
-    }
-    else {
-        axis_pos = priv->axis_pos;
-    }
-
-    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 0, sizeof (cl_mem), &in_mem));
-    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 1, sizeof (cl_mem), &out_mem));
-    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 2, sizeof (cl_mem), &priv->sin_lut));
-    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 3, sizeof (cl_mem), &priv->cos_lut));
-    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 4, sizeof (guint),  &priv->roi_x));
-    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 5, sizeof (guint),  &priv->roi_y));
-    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 6, sizeof (guint),  &priv->offset));
-    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 7, sizeof (guint),  &priv->burst_projections));
-    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 8, sizeof (gfloat), &axis_pos));
-
-    profiler = ufo_task_node_get_profiler (UFO_TASK_NODE (task));
-
-    if (priv->mode == MODE_LINEAR || priv->mode == MODE_CUBIC) {
-        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 9, sizeof (cl_int), &width));
-        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 10, sizeof (cl_int), &height));
-        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 11, sizeof (cl_int), &sino_width));
-        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 12, sizeof (cl_int), &between_0_180));
-        ufo_profiler_call (profiler, cmd_queue, kernel, 2, global_size, local_size);
-        /* UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 9, sizeof (cl_int), &sino_width)); */
-        /* ufo_profiler_call (profiler, cmd_queue, kernel, 2, requisition->dims, NULL); */
+        /* Pack sinogram */
+        sinogram_size = in_req.dims[0] * in_req.dims[1];
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (priv->interleave_kernel, 0, sizeof (cl_mem), &in_mem));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (priv->interleave_kernel, 1, sizeof (cl_mem), &priv->sino_stack_mem));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (priv->interleave_kernel, 2, sizeof (cl_int), &priv->current));
+        ufo_profiler_call (profiler, cmd_queue, priv->interleave_kernel, 1, &sinogram_size, NULL);
     } else {
+        /* Reconstruct directly withouth packing */
+        kernel = priv->kernels[priv->mode];
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 0, sizeof (cl_mem), &in_mem));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 1, sizeof (cl_mem), &out_mem));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 2, sizeof (cl_mem), &priv->sin_lut));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 3, sizeof (cl_mem), &priv->cos_lut));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 4, sizeof (guint),  &priv->roi_x));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 5, sizeof (guint),  &priv->roi_y));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 6, sizeof (guint),  &priv->offset));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 7, sizeof (guint),  &priv->burst_projections));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 8, sizeof (gfloat), &priv->axis_pos));
         ufo_profiler_call (profiler, cmd_queue, kernel, 2, requisition->dims, NULL);
     }
 
+    priv->current++;
+    priv->num_packed = priv->current;
+
+    if (priv->current % priv->pack) {
+        return TRUE;
+    } else {
+        if (priv->mode == MODE_LINEAR || priv->mode == MODE_CUBIC) {
+            backproject_new (task, requisition);
+        }
+        return FALSE;
+    }
+}
+
+static gboolean
+ufo_backproject_task_generate (UfoTask *task,
+                               UfoBuffer *output,
+                               UfoRequisition *requisition)
+{
+    UfoBackprojectTaskPrivate *priv;
+    UfoGpuNode *node;
+    UfoProfiler *profiler;
+    cl_command_queue cmd_queue;
+    cl_mem out_mem;
+    gsize slice_size;
+    cl_int current;
+
+    priv = UFO_BACKPROJECT_TASK (task)->priv;
+
+    if (priv->inputs_stopped && (priv->mode == MODE_LINEAR || priv->mode == MODE_CUBIC)) {
+        backproject_new (task, requisition);
+        priv->inputs_stopped = FALSE;
+    }
+
+    if (!priv->current) {
+        return FALSE;
+    }
+
+    if (priv->mode == MODE_LINEAR || priv->mode == MODE_CUBIC) {
+        node = UFO_GPU_NODE (ufo_task_node_get_proc_node (UFO_TASK_NODE (task)));
+        cmd_queue = ufo_gpu_node_get_cmd_queue (node);
+        out_mem = ufo_buffer_get_device_array (output, cmd_queue);
+        profiler = ufo_task_node_get_profiler (UFO_TASK_NODE (task));
+
+
+        slice_size = requisition->dims[0] * requisition->dims[1];
+        current = priv->num_packed - priv->current;
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (priv->uninterleave_kernel, 0, sizeof (cl_mem), &out_mem));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (priv->uninterleave_kernel, 1, sizeof (cl_mem), &priv->slice_stack_mem));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (priv->uninterleave_kernel, 2, sizeof (cl_int), &current));
+        ufo_profiler_call (profiler, cmd_queue, priv->uninterleave_kernel, 1, &slice_size, NULL);
+    }
+
+    priv->current--;
+
     return TRUE;
+}
+
+static void inputs_stopped_callback (UfoTask *task)
+{
+    UfoBackprojectTaskPrivate *priv = UFO_BACKPROJECT_TASK_GET_PRIVATE (task);
+    /* We packed less rows, generate needs to know this and potentially
+     * reconstruct the remaining rows before the full priv->pack is filled */
+    priv->num_packed = priv->current;
+
+    if (priv->current != priv->pack) {
+        /* Only back project in generate if inputs were stopped before being a
+         * divisor of priv->pack */
+        priv->inputs_stopped = TRUE;
+    }
 }
 
 static void
@@ -213,6 +302,8 @@ ufo_backproject_task_setup (UfoTask *task,
     priv->kernels[MODE_TEXTURE] = ufo_resources_get_kernel (resources, "backproject.cl", "backproject_tex", NULL, error);
     priv->kernels[MODE_LINEAR] = ufo_resources_get_kernel (resources, "backproject.cl", "backproject_linear", NULL, error);
     priv->kernels[MODE_CUBIC] = ufo_resources_get_kernel (resources, "backproject.cl", "backproject_cubic", NULL, error);
+    priv->interleave_kernel = ufo_resources_get_kernel (resources, "backproject.cl", "interleave", NULL, error);
+    priv->uninterleave_kernel = ufo_resources_get_kernel (resources, "backproject.cl", "uninterleave", NULL, error);
 
     UFO_RESOURCES_CHECK_SET_AND_RETURN (clRetainContext (priv->context), error);
 
@@ -222,6 +313,8 @@ ufo_backproject_task_setup (UfoTask *task,
         }
     }
 
+    UFO_RESOURCES_CHECK_SET_AND_RETURN (clRetainKernel (priv->interleave_kernel), error);
+    UFO_RESOURCES_CHECK_SET_AND_RETURN (clRetainKernel (priv->uninterleave_kernel), error);
 }
 
 static cl_mem
@@ -270,10 +363,12 @@ ufo_backproject_task_get_requisition (UfoTask *task,
 {
     UfoBackprojectTaskPrivate *priv;
     UfoRequisition in_req;
+    cl_int errcode;
 
     priv = UFO_BACKPROJECT_TASK_GET_PRIVATE (task);
     ufo_buffer_get_requisition (inputs[0], &in_req);
 
+    priv->sino_width = in_req.dims[0];
     /* If the number of projections is not specified use the input size */
     if (priv->n_projections == 0) {
         priv->n_projections = (guint) in_req.dims[1];
@@ -287,6 +382,11 @@ ufo_backproject_task_get_requisition (UfoTask *task,
                      "or equal to sinogram height (%u)",
                      priv->n_projections, priv->burst_projections);
         return;
+    }
+
+    /* Guess axis position if they are not provided by the user. */
+    if (priv->axis_pos <= 0.0) {
+        priv->axis_pos = (gfloat) ((gfloat) in_req.dims[0]) / 2.0f;
     }
 
     requisition->n_dims = 2;
@@ -317,6 +417,28 @@ ufo_backproject_task_get_requisition (UfoTask *task,
         priv->cos_lut = create_lut_buffer (priv, &priv->host_cos_lut,
                                            priv->n_projections, cos);
     }
+
+    if (priv->sino_stack_mem == NULL) {
+        priv->sino_stack_mem = clCreateBuffer (
+            priv->context,
+            CL_MEM_READ_WRITE,
+            in_req.dims[0] * in_req.dims[1] * priv->pack * sizeof (cl_float),
+            NULL,
+            &errcode
+        );
+        UFO_RESOURCES_CHECK_CLERR (errcode);
+    }
+
+    if (priv->slice_stack_mem == NULL) {
+        priv->slice_stack_mem = clCreateBuffer (
+            priv->context,
+            CL_MEM_READ_WRITE,
+            requisition->dims[0] * requisition->dims[1] * priv->pack * sizeof (cl_float),
+            NULL,
+            &errcode
+        );
+        UFO_RESOURCES_CHECK_CLERR (errcode);
+    }
 }
 
 static guint
@@ -336,7 +458,7 @@ ufo_filter_task_get_num_dimensions (UfoTask *task,
 static UfoTaskMode
 ufo_filter_task_get_mode (UfoTask *task)
 {
-    return UFO_TASK_MODE_PROCESSOR | UFO_TASK_MODE_GPU;
+    return UFO_TASK_MODE_REDUCTOR | UFO_TASK_MODE_GPU;
 }
 
 static gboolean
@@ -355,6 +477,14 @@ ufo_backproject_task_finalize (GObject *object)
     priv = UFO_BACKPROJECT_TASK_GET_PRIVATE (object);
 
     release_lut_mems (priv);
+    if (priv->sino_stack_mem) {
+        UFO_RESOURCES_CHECK_CLERR (clReleaseMemObject (priv->sino_stack_mem));
+        priv->sino_stack_mem = NULL;
+    }
+    if (priv->slice_stack_mem) {
+        UFO_RESOURCES_CHECK_CLERR (clReleaseMemObject (priv->slice_stack_mem));
+        priv->slice_stack_mem = NULL;
+    }
 
     g_free (priv->host_sin_lut);
     g_free (priv->host_cos_lut);
@@ -365,6 +495,11 @@ ufo_backproject_task_finalize (GObject *object)
             priv->kernels[i] = NULL;
         }
     }
+
+    UFO_RESOURCES_CHECK_CLERR (clReleaseKernel (priv->interleave_kernel));
+    priv->interleave_kernel = NULL;
+    UFO_RESOURCES_CHECK_CLERR (clReleaseKernel (priv->uninterleave_kernel));
+    priv->uninterleave_kernel = NULL;
 
     if (priv->context) {
         UFO_RESOURCES_CHECK_CLERR (clReleaseContext (priv->context));
@@ -383,6 +518,7 @@ ufo_task_interface_init (UfoTaskIface *iface)
     iface->get_num_dimensions = ufo_filter_task_get_num_dimensions;
     iface->get_mode = ufo_filter_task_get_mode;
     iface->process = ufo_backproject_task_process;
+    iface->generate = ufo_backproject_task_generate;
 }
 
 static void
@@ -401,7 +537,7 @@ ufo_backproject_task_set_property (GObject *object,
             priv->offset = g_value_get_uint (value);
             break;
         case PROP_AXIS_POSITION:
-            priv->axis_pos = g_value_get_double (value);
+            priv->axis_pos = g_value_get_float (value);
             break;
         case PROP_ANGLE_STEP:
             priv->angle_step = g_value_get_double (value);
@@ -412,6 +548,9 @@ ufo_backproject_task_set_property (GObject *object,
             break;
         case PROP_MODE:
             priv->mode = g_value_get_enum (value);
+            if (priv->mode == MODE_LINEAR || priv->mode == MODE_CUBIC) {
+                priv->pack = 4;
+            }
             break;
         case PROP_ROI_X:
             priv->roi_x = g_value_get_uint (value);
@@ -447,7 +586,7 @@ ufo_backproject_task_get_property (GObject *object,
             g_value_set_uint (value, priv->offset);
             break;
         case PROP_AXIS_POSITION:
-            g_value_set_double (value, priv->axis_pos);
+            g_value_set_float (value, priv->axis_pos);
             break;
         case PROP_ANGLE_STEP:
             g_value_set_double (value, priv->angle_step);
@@ -504,7 +643,7 @@ ufo_backproject_task_class_init (UfoBackprojectTaskClass *klass)
             G_PARAM_READWRITE);
 
     properties[PROP_AXIS_POSITION] =
-        g_param_spec_double ("axis-pos",
+        g_param_spec_float ("axis-pos",
             "Position of rotation axis",
             "Position of rotation axis",
             -1.0, +32768.0, 0.0,
@@ -575,6 +714,8 @@ ufo_backproject_task_init (UfoBackprojectTask *self)
     for (int i = 0; i < NUM_MODES; i++) {
         priv->kernels[i] = NULL;
     }
+    priv->interleave_kernel = NULL;
+    priv->uninterleave_kernel = NULL;
     priv->n_projections = 0;
     priv->offset = 0;
     priv->axis_pos = -1.0;
@@ -583,10 +724,16 @@ ufo_backproject_task_init (UfoBackprojectTask *self)
     priv->real_angle_step = -1.0;
     priv->sin_lut = NULL;
     priv->cos_lut = NULL;
+    priv->sino_stack_mem = NULL;
+    priv->slice_stack_mem = NULL;
     priv->host_sin_lut = NULL;
     priv->host_cos_lut = NULL;
     priv->mode = MODE_TEXTURE;
     priv->luts_changed = TRUE;
     priv->roi_x = priv->roi_y = 0;
     priv->roi_width = priv->roi_height = 0;
+    priv->pack = 1;
+    priv->current = 0;
+    priv->inputs_stopped = FALSE;
+    g_signal_connect (self, "inputs_stopped", (GCallback) inputs_stopped_callback, NULL);
 }

--- a/src/ufo-backproject-task.c
+++ b/src/ufo-backproject-task.c
@@ -677,8 +677,8 @@ ufo_backproject_task_class_init (UfoBackprojectTaskClass *klass)
 
     properties[PROP_MODE] =
         g_param_spec_enum ("mode",
-            "Backprojection mode (\"nearest\", \"texture\", \"cubic\")",
-            "Backprojection mode (\"nearest\", \"texture\", \"cubic\")",
+            "Backprojection mode (\"nearest\", \"texture\", \"linear\", \"cubic\")",
+            "Backprojection mode (\"nearest\", \"texture\", \"linear\", \"cubic\")",
             g_enum_register_static ("ufo_backproject_mode", mode_values),
             MODE_TEXTURE, G_PARAM_READWRITE);
 

--- a/src/ufo-backproject-task.c
+++ b/src/ufo-backproject-task.c
@@ -30,12 +30,14 @@
 
 typedef enum {
     MODE_NEAREST,
-    MODE_TEXTURE
+    MODE_TEXTURE,
+    MODE_CUBIC
 } Mode;
 
 static GEnumValue mode_values[] = {
     { MODE_NEAREST, "MODE_NEAREST", "nearest" },
     { MODE_TEXTURE, "MODE_TEXTURE", "texture" },
+    { MODE_CUBIC, "MODE_CUBIC", "cubic" },
     { 0, NULL, NULL}
 };
 
@@ -43,6 +45,7 @@ struct _UfoBackprojectTaskPrivate {
     cl_context context;
     cl_kernel nearest_kernel;
     cl_kernel texture_kernel;
+    cl_kernel cubic_kernel;
     cl_mem sin_lut;
     cl_mem cos_lut;
     gfloat *host_sin_lut;
@@ -113,13 +116,19 @@ ufo_backproject_task_process (UfoTask *task,
     cmd_queue = ufo_gpu_node_get_cmd_queue (node);
     out_mem = ufo_buffer_get_device_array (output, cmd_queue);
 
-    if (priv->mode == MODE_TEXTURE) {
-        in_mem = ufo_buffer_get_device_image (inputs[0], cmd_queue);
-        kernel = priv->texture_kernel;
-    }
-    else {
-        in_mem = ufo_buffer_get_device_array (inputs[0], cmd_queue);
-        kernel = priv->nearest_kernel;
+    switch (priv->mode) {
+        case MODE_NEAREST:
+            in_mem = ufo_buffer_get_device_array (inputs[0], cmd_queue);
+            kernel = priv->nearest_kernel;
+            break;
+        case MODE_TEXTURE:
+            in_mem = ufo_buffer_get_device_image (inputs[0], cmd_queue);
+            kernel = priv->texture_kernel;
+            break;
+        case MODE_CUBIC:
+            in_mem = ufo_buffer_get_device_array (inputs[0], cmd_queue);
+            kernel = priv->cubic_kernel;
+            break;
     }
 
     /* Guess axis position if they are not provided by the user. */
@@ -161,6 +170,7 @@ ufo_backproject_task_setup (UfoTask *task,
     priv->context = ufo_resources_get_context (resources);
     priv->nearest_kernel = ufo_resources_get_kernel (resources, "backproject.cl", "backproject_nearest", NULL, error);
     priv->texture_kernel = ufo_resources_get_kernel (resources, "backproject.cl", "backproject_tex", NULL, error);
+    priv->cubic_kernel = ufo_resources_get_kernel (resources, "backproject.cl", "backproject_cubic", NULL, error);
 
     UFO_RESOURCES_CHECK_SET_AND_RETURN (clRetainContext (priv->context), error);
 
@@ -169,6 +179,9 @@ ufo_backproject_task_setup (UfoTask *task,
 
     if (priv->texture_kernel != NULL)
         UFO_RESOURCES_CHECK_SET_AND_RETURN (clRetainKernel (priv->texture_kernel), error);
+
+    if (priv->cubic_kernel != NULL)
+        UFO_RESOURCES_CHECK_SET_AND_RETURN (clRetainKernel (priv->cubic_kernel), error);
 }
 
 static cl_mem
@@ -314,6 +327,11 @@ ufo_backproject_task_finalize (GObject *object)
     if (priv->texture_kernel) {
         UFO_RESOURCES_CHECK_CLERR (clReleaseKernel (priv->texture_kernel));
         priv->texture_kernel = NULL;
+    }
+
+    if (priv->cubic_kernel) {
+        UFO_RESOURCES_CHECK_CLERR (clReleaseKernel (priv->cubic_kernel));
+        priv->cubic_kernel = NULL;
     }
 
     if (priv->context) {
@@ -476,8 +494,8 @@ ufo_backproject_task_class_init (UfoBackprojectTaskClass *klass)
 
     properties[PROP_MODE] =
         g_param_spec_enum ("mode",
-            "Backprojection mode (\"nearest\", \"texture\")",
-            "Backprojection mode (\"nearest\", \"texture\")",
+            "Backprojection mode (\"nearest\", \"texture\", \"cubic\")",
+            "Backprojection mode (\"nearest\", \"texture\", \"cubic\")",
             g_enum_register_static ("ufo_backproject_mode", mode_values),
             MODE_TEXTURE, G_PARAM_READWRITE);
 
@@ -524,6 +542,7 @@ ufo_backproject_task_init (UfoBackprojectTask *self)
     self->priv = priv = UFO_BACKPROJECT_TASK_GET_PRIVATE (self);
     priv->nearest_kernel = NULL;
     priv->texture_kernel = NULL;
+    priv->cubic_kernel = NULL;
     priv->n_projections = 0;
     priv->offset = 0;
     priv->axis_pos = -1.0;

--- a/src/ufo-backproject-task.c
+++ b/src/ufo-backproject-task.c
@@ -69,6 +69,7 @@ struct _UfoBackprojectTaskPrivate {
     gint pack, num_packed, current;
     gint sino_width;
     gboolean inputs_stopped;
+    gsize local_size[2];
     Mode mode;
 };
 
@@ -116,7 +117,7 @@ backproject_new (UfoTask *task, UfoRequisition *requisition)
     guint num_processed;
     GValue *work_group_size_gvalue;
     /* TODO downsize like in transpose until GPU max work group size is satisfied */
-    gsize local_size[2], global_size[2];
+    gsize global_size[2];
 
     priv = UFO_BACKPROJECT_TASK_GET_PRIVATE (task);
     node = UFO_GPU_NODE (ufo_task_node_get_proc_node (UFO_TASK_NODE (task)));
@@ -131,12 +132,15 @@ backproject_new (UfoTask *task, UfoRequisition *requisition)
         || priv->angle_offset + (priv->n_projections - 1) * priv->real_angle_step > M_PI) {
         between_0_180 = 0;
     }
-    work_group_size_gvalue = ufo_gpu_node_get_info (node, UFO_GPU_NODE_INFO_MAX_WORK_GROUP_SIZE);
-    /* Use maximum possible work group size as width and height one */
-    local_size[0] = g_value_get_ulong (work_group_size_gvalue) / priv->pack;
-    local_size[1] = 1;
-    g_value_unset (work_group_size_gvalue);
-    global_size[0] = ((requisition->dims[0] - 1) / local_size[0] + 1) * local_size[0];
+    if (!priv->local_size[0]) {
+        work_group_size_gvalue = ufo_gpu_node_get_info (node, UFO_GPU_NODE_INFO_MAX_WORK_GROUP_SIZE);
+        /* Use maximum possible work group size as width and height one. For
+         * packed kernels maximum local size leads to CL_OUT_OF_RESOURCES, so
+         * use only 1 / priv->pack of the maximum by default. */
+        priv->local_size[0] = g_value_get_ulong (work_group_size_gvalue) / priv->pack;
+        g_value_unset (work_group_size_gvalue);
+    }
+    global_size[0] = ((requisition->dims[0] - 1) / priv->local_size[0] + 1) * priv->local_size[0];
     /* Global size has PIXELS_PER_THREAD less rows because one thread
      * processes PIXELS_PER_THREAD rows */
     global_size[1] = ((requisition->dims[1] - 1) / PIXELS_PER_THREAD + 1);
@@ -146,7 +150,7 @@ backproject_new (UfoTask *task, UfoRequisition *requisition)
     if (num_processed == priv->pack - 1) {
         g_debug ("backproject: angles between 0 - 180: %d", between_0_180);
         g_debug ("backproject: global size: %lu %lu, local size: %lu %lu, sino width and height: %d %u",
-                 global_size[0], global_size[1], local_size[0], local_size[1], priv->sino_width, priv->burst_projections);
+                 global_size[0], global_size[1], priv->local_size[0], priv->local_size[1], priv->sino_width, priv->burst_projections);
     }
 
     UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 0, sizeof (cl_mem), &priv->sino_stack_mem));
@@ -162,7 +166,15 @@ backproject_new (UfoTask *task, UfoRequisition *requisition)
     UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 10, sizeof (cl_int), &height));
     UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 11, sizeof (cl_int), &priv->sino_width));
     UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 12, sizeof (cl_int), &between_0_180));
-    ufo_profiler_call (profiler, cmd_queue, kernel, 2, global_size, local_size);
+    while (ufo_profiler_call (profiler, cmd_queue, kernel, 2, global_size, priv->local_size)) {
+        /* If 1 / priv->pack is still too large, keep halving until OpenCL is satisfied */
+        g_warning ("local size %lu too large, reducing by 2", priv->local_size[0]);
+        priv->local_size[0] /= 2;
+        if (!priv->local_size[0]) {
+            g_error ("No suitable local size was found");
+            break;
+        }
+    }
 }
 
 static gboolean
@@ -735,5 +747,7 @@ ufo_backproject_task_init (UfoBackprojectTask *self)
     priv->pack = 1;
     priv->current = 0;
     priv->inputs_stopped = FALSE;
+    priv->local_size[0] = 0;
+    priv->local_size[1] = 1;
     g_signal_connect (self, "inputs_stopped", (GCallback) inputs_stopped_callback, NULL);
 }

--- a/src/ufo-backproject-task.c
+++ b/src/ufo-backproject-task.c
@@ -27,25 +27,27 @@
 #include <math.h>
 #include "ufo-backproject-task.h"
 
+#define PIXELS_PER_THREAD 8
 
 typedef enum {
     MODE_NEAREST,
     MODE_TEXTURE,
-    MODE_CUBIC
+    MODE_LINEAR,
+    MODE_CUBIC,
+    NUM_MODES
 } Mode;
 
 static GEnumValue mode_values[] = {
     { MODE_NEAREST, "MODE_NEAREST", "nearest" },
     { MODE_TEXTURE, "MODE_TEXTURE", "texture" },
-    { MODE_CUBIC, "MODE_CUBIC", "cubic" },
+    { MODE_LINEAR,  "MODE_LINEAR",  "linear" },
+    { MODE_CUBIC,   "MODE_CUBIC",   "cubic" },
     { 0, NULL, NULL}
 };
 
 struct _UfoBackprojectTaskPrivate {
     cl_context context;
-    cl_kernel nearest_kernel;
-    cl_kernel texture_kernel;
-    cl_kernel cubic_kernel;
+    cl_kernel kernels[NUM_MODES];
     cl_mem sin_lut;
     cl_mem cos_lut;
     gfloat *host_sin_lut;
@@ -105,37 +107,65 @@ ufo_backproject_task_process (UfoTask *task,
     UfoBackprojectTaskPrivate *priv;
     UfoGpuNode *node;
     UfoProfiler *profiler;
+    UfoRequisition in_req;
     cl_command_queue cmd_queue;
     cl_mem in_mem;
     cl_mem out_mem;
     cl_kernel kernel;
+    cl_int sino_width, width, height;
+    cl_int between_0_180 = 1;
+    guint num_processed;
     gfloat axis_pos;
+    GValue *work_group_size_gvalue;
+    /* TODO downsize like in transpose until GPU max work group size is satisfied */
+    gsize local_size[2], global_size[2];
 
     priv = UFO_BACKPROJECT_TASK (task)->priv;
     node = UFO_GPU_NODE (ufo_task_node_get_proc_node (UFO_TASK_NODE (task)));
     cmd_queue = ufo_gpu_node_get_cmd_queue (node);
     out_mem = ufo_buffer_get_device_array (output, cmd_queue);
+    ufo_buffer_get_requisition (inputs[0], &in_req);
 
-    switch (priv->mode) {
-        case MODE_NEAREST:
-            in_mem = ufo_buffer_get_device_array (inputs[0], cmd_queue);
-            kernel = priv->nearest_kernel;
-            break;
-        case MODE_TEXTURE:
-            in_mem = ufo_buffer_get_device_image (inputs[0], cmd_queue);
-            kernel = priv->texture_kernel;
-            break;
-        case MODE_CUBIC:
-            in_mem = ufo_buffer_get_device_array (inputs[0], cmd_queue);
-            kernel = priv->cubic_kernel;
-            break;
+    kernel = priv->kernels[priv->mode];
+
+    /* We need an image if mode is texture, otherwise just the array */
+    if (priv->mode == MODE_TEXTURE) {
+        in_mem = ufo_buffer_get_device_image (inputs[0], cmd_queue);
+    } else {
+        in_mem = ufo_buffer_get_device_array (inputs[0], cmd_queue);
+    }
+
+    if (priv->mode == MODE_LINEAR || priv->mode == MODE_CUBIC) {
+        /* We get better performance if we do not need to check for left shift
+         * in the kernels, so figure this out here and make a global flag */
+        if (priv->angle_offset < 0.0 || priv->angle_offset > M_PI
+            || priv->angle_offset + (priv->n_projections - 1) * priv->real_angle_step < 0.0
+            || priv->angle_offset + (priv->n_projections - 1) * priv->real_angle_step > M_PI) {
+            between_0_180 = 0;
+        }
+        in_mem = ufo_buffer_get_device_array (inputs[0], cmd_queue);
+        work_group_size_gvalue = ufo_gpu_node_get_info (node, UFO_GPU_NODE_INFO_MAX_WORK_GROUP_SIZE);
+        /* Use maximum possible work group size as width and height one */
+        local_size[0] = g_value_get_ulong (work_group_size_gvalue);
+        local_size[1] = 1;
+        g_value_unset (work_group_size_gvalue);
+        global_size[0] = ((requisition->dims[0] - 1) / local_size[0] + 1) * local_size[0];
+        /* Global size has PIXELS_PER_THREAD less rows because one thread
+         * processes PIXELS_PER_THREAD rows */
+        global_size[1] = ((requisition->dims[1] - 1) / PIXELS_PER_THREAD + 1);
+        width = (cl_int) requisition->dims[0];
+        height = (cl_int) requisition->dims[1];
+        sino_width = (cl_int) in_req.dims[0];
+        g_object_get (task, "num_processed", &num_processed, NULL);
+        if (num_processed == 0) {
+            g_debug ("backproject: angles between 0 - 180: %d", between_0_180);
+            g_debug ("backproject: global size: %lu %lu, local size: %lu %lu, sino width and height: %d %u",
+                     global_size[0], global_size[1], local_size[0], local_size[1], sino_width, priv->burst_projections);
+        }
     }
 
     /* Guess axis position if they are not provided by the user. */
     if (priv->axis_pos <= 0.0) {
-        UfoRequisition in_req;
-
-        ufo_buffer_get_requisition (inputs[0], &in_req);
         axis_pos = (gfloat) ((gfloat) in_req.dims[0]) / 2.0f;
     }
     else {
@@ -153,7 +183,18 @@ ufo_backproject_task_process (UfoTask *task,
     UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 8, sizeof (gfloat), &axis_pos));
 
     profiler = ufo_task_node_get_profiler (UFO_TASK_NODE (task));
-    ufo_profiler_call (profiler, cmd_queue, kernel, 2, requisition->dims, NULL);
+
+    if (priv->mode == MODE_LINEAR || priv->mode == MODE_CUBIC) {
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 9, sizeof (cl_int), &width));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 10, sizeof (cl_int), &height));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 11, sizeof (cl_int), &sino_width));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 12, sizeof (cl_int), &between_0_180));
+        ufo_profiler_call (profiler, cmd_queue, kernel, 2, global_size, local_size);
+        /* UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 9, sizeof (cl_int), &sino_width)); */
+        /* ufo_profiler_call (profiler, cmd_queue, kernel, 2, requisition->dims, NULL); */
+    } else {
+        ufo_profiler_call (profiler, cmd_queue, kernel, 2, requisition->dims, NULL);
+    }
 
     return TRUE;
 }
@@ -168,20 +209,19 @@ ufo_backproject_task_setup (UfoTask *task,
     priv = UFO_BACKPROJECT_TASK_GET_PRIVATE (task);
 
     priv->context = ufo_resources_get_context (resources);
-    priv->nearest_kernel = ufo_resources_get_kernel (resources, "backproject.cl", "backproject_nearest", NULL, error);
-    priv->texture_kernel = ufo_resources_get_kernel (resources, "backproject.cl", "backproject_tex", NULL, error);
-    priv->cubic_kernel = ufo_resources_get_kernel (resources, "backproject.cl", "backproject_cubic", NULL, error);
+    priv->kernels[MODE_NEAREST] = ufo_resources_get_kernel (resources, "backproject.cl", "backproject_nearest", NULL, error);
+    priv->kernels[MODE_TEXTURE] = ufo_resources_get_kernel (resources, "backproject.cl", "backproject_tex", NULL, error);
+    priv->kernels[MODE_LINEAR] = ufo_resources_get_kernel (resources, "backproject.cl", "backproject_linear", NULL, error);
+    priv->kernels[MODE_CUBIC] = ufo_resources_get_kernel (resources, "backproject.cl", "backproject_cubic", NULL, error);
 
     UFO_RESOURCES_CHECK_SET_AND_RETURN (clRetainContext (priv->context), error);
 
-    if (priv->nearest_kernel != NULL)
-        UFO_RESOURCES_CHECK_SET_AND_RETURN (clRetainKernel (priv->nearest_kernel), error);
+    for (int i = 0; i < NUM_MODES; i++) {
+        if (priv->kernels[i] != NULL) {
+            UFO_RESOURCES_CHECK_SET_AND_RETURN (clRetainKernel (priv->kernels[i]), error);
+        }
+    }
 
-    if (priv->texture_kernel != NULL)
-        UFO_RESOURCES_CHECK_SET_AND_RETURN (clRetainKernel (priv->texture_kernel), error);
-
-    if (priv->cubic_kernel != NULL)
-        UFO_RESOURCES_CHECK_SET_AND_RETURN (clRetainKernel (priv->cubic_kernel), error);
 }
 
 static cl_mem
@@ -304,7 +344,7 @@ ufo_backproject_task_equal_real (UfoNode *n1,
                             UfoNode *n2)
 {
     g_return_val_if_fail (UFO_IS_BACKPROJECT_TASK (n1) && UFO_IS_BACKPROJECT_TASK (n2), FALSE);
-    return UFO_BACKPROJECT_TASK (n1)->priv->texture_kernel == UFO_BACKPROJECT_TASK (n2)->priv->texture_kernel;
+    return UFO_BACKPROJECT_TASK (n1)->priv->kernels[0] == UFO_BACKPROJECT_TASK (n2)->priv->kernels[0];
 }
 
 static void
@@ -319,19 +359,11 @@ ufo_backproject_task_finalize (GObject *object)
     g_free (priv->host_sin_lut);
     g_free (priv->host_cos_lut);
 
-    if (priv->nearest_kernel) {
-        UFO_RESOURCES_CHECK_CLERR (clReleaseKernel (priv->nearest_kernel));
-        priv->nearest_kernel = NULL;
-    }
-
-    if (priv->texture_kernel) {
-        UFO_RESOURCES_CHECK_CLERR (clReleaseKernel (priv->texture_kernel));
-        priv->texture_kernel = NULL;
-    }
-
-    if (priv->cubic_kernel) {
-        UFO_RESOURCES_CHECK_CLERR (clReleaseKernel (priv->cubic_kernel));
-        priv->cubic_kernel = NULL;
+    for (int i = 0; i < NUM_MODES; i++) {
+        if (priv->kernels[i]) {
+            UFO_RESOURCES_CHECK_CLERR (clReleaseKernel (priv->kernels[i]));
+            priv->kernels[i] = NULL;
+        }
     }
 
     if (priv->context) {
@@ -540,9 +572,9 @@ ufo_backproject_task_init (UfoBackprojectTask *self)
 {
     UfoBackprojectTaskPrivate *priv;
     self->priv = priv = UFO_BACKPROJECT_TASK_GET_PRIVATE (self);
-    priv->nearest_kernel = NULL;
-    priv->texture_kernel = NULL;
-    priv->cubic_kernel = NULL;
+    for (int i = 0; i < NUM_MODES; i++) {
+        priv->kernels[i] = NULL;
+    }
     priv->n_projections = 0;
     priv->offset = 0;
     priv->axis_pos = -1.0;

--- a/src/ufo-backproject-task.c
+++ b/src/ufo-backproject-task.c
@@ -27,7 +27,7 @@
 #include <math.h>
 #include "ufo-backproject-task.h"
 
-#define PIXELS_PER_THREAD 8
+#define PIXELS_PER_THREAD 16
 
 typedef enum {
     MODE_NEAREST,

--- a/src/ufo-backproject-task.c
+++ b/src/ufo-backproject-task.c
@@ -549,7 +549,7 @@ ufo_backproject_task_set_property (GObject *object,
             priv->offset = g_value_get_uint (value);
             break;
         case PROP_AXIS_POSITION:
-            priv->axis_pos = g_value_get_float (value);
+            priv->axis_pos = (gfloat) g_value_get_double (value);
             break;
         case PROP_ANGLE_STEP:
             priv->angle_step = g_value_get_double (value);
@@ -560,9 +560,7 @@ ufo_backproject_task_set_property (GObject *object,
             break;
         case PROP_MODE:
             priv->mode = g_value_get_enum (value);
-            if (priv->mode == MODE_LINEAR || priv->mode == MODE_CUBIC) {
-                priv->pack = 4;
-            }
+            priv->pack = (priv->mode == MODE_LINEAR || priv->mode == MODE_CUBIC) ? 4 : 1;
             break;
         case PROP_ROI_X:
             priv->roi_x = g_value_get_uint (value);
@@ -598,7 +596,7 @@ ufo_backproject_task_get_property (GObject *object,
             g_value_set_uint (value, priv->offset);
             break;
         case PROP_AXIS_POSITION:
-            g_value_set_float (value, priv->axis_pos);
+            g_value_set_double (value, priv->axis_pos);
             break;
         case PROP_ANGLE_STEP:
             g_value_set_double (value, priv->angle_step);
@@ -655,7 +653,7 @@ ufo_backproject_task_class_init (UfoBackprojectTaskClass *klass)
             G_PARAM_READWRITE);
 
     properties[PROP_AXIS_POSITION] =
-        g_param_spec_float ("axis-pos",
+        g_param_spec_double ("axis-pos",
             "Position of rotation axis",
             "Position of rotation axis",
             -1.0, +32768.0, 0.0,


### PR DESCRIPTION
Adds a "manual" linear interpolation and a cubic one. Numbers from `ufo-prof` ran 3x (`texture_single` is `stacked-backproject` with `precicion-mode=single`):

## Performance results

### GeForce RTX 2080 Ti
```bash
         backproject_tex: 41.09 ms
      backproject_linear: 15.39 ms
       backproject_cubic: 39.32 ms
          texture_single: 13.98 ms
```

### GeForce RTX 4060 Ti
```bash
         backproject_tex: 44.18 ms
      backproject_linear: 20.49 ms
       backproject_cubic: 51.47 ms
          texture_single: 18.07 ms
```
### RTX A4000
```bash
         backproject_tex: 74.46 ms
      backproject_linear: 23.02 ms
       backproject_cubic: 52.05 ms
          texture_single: 20.93 ms
```
### RTX A5000
```bash
         backproject_tex: 56.43 ms
      backproject_linear: 16.02 ms
       backproject_cubic: 36.53 ms
          texture_single: 14.53 ms
```

It is just this script with a bit of cleaning up:
```bash
export CUDA_VISIBLE_DEVICES=0

for MODE in texture linear cubic
do
    echo $MODE
    for INDEX in $(seq 3)
        do ufo-launch -q -t dummy-data width=2048 height=3000 number=128 ! backproject mode=$MODE ! null download=True
    done
done

# Test stacked-backproject as well
for INDEX in $(seq 3)
    do ufo-launch -q -t dummy-data width=2048 height=3000 number=128 ! stack number=2 ! stacked-backproject precision-mode=single ! null download=True
done
```

Todos:

- [x] fix docs
- [ ] properly handle between_0_180

Cubic is a bit slower but linear is a bit faster than by doing it with texture memory.