### PR TITLE
Add frequency sharpening

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -1074,6 +1074,29 @@ Frequency filtering
         Theta parameter of Faris-Byer filter.
 
 
+.. gobj:class:: frequency-sharpen
+
+    Sharpen 2D frequency-domain data. The input and output are complex
+    interleaved Fourier coefficients, for example from ``fft dimensions=2``.
+
+    Example usage::
+
+        $ ufo-launch read path=input.tif ! fft dimensions=2 ! frequency-sharpen strength=1.0 ! ifft dimensions=2 ! write filename=sharpened.tif
+
+    .. gobj:prop:: strength:float
+
+        Sharpening strength.
+
+    .. gobj:prop:: method:string
+
+        Sharpening method, one of ``laplace``, ``discrete-laplace`` or
+        ``lorentz``.
+
+    .. gobj:prop:: lorentz-fwhm:float
+
+        Full width at half maximum of the Lorentz blur kernel.
+
+
 Stripe filtering
 ----------------
 

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -1096,6 +1096,11 @@ Frequency filtering
 
         Full width at half maximum of the Lorentz blur kernel.
 
+    .. gobj:prop:: max-boost:float
+
+        Maximum additional boost for all sharpening methods. A value of ``0``
+        disables tanh limiting.
+
 
 Stripe filtering
 ----------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(ufofilter_SRCS
     ufo-flat-field-correct-task.c
     ufo-fft-task.c
     ufo-fftmult-task.c
+    ufo-frequency-sharpen-task.c
     ufo-filter-particle-task.c
     ufo-filter-stripes-task.c
     ufo-filter-stripes1d-task.c

--- a/src/kernels/meson.build
+++ b/src/kernels/meson.build
@@ -41,6 +41,7 @@ kernel_files = [
     'rm-outliers.cl',
     'rotate.cl',
     'segment.cl',
+    'sharpening.cl',
     'split.cl',
     'stacked-backproject.cl',
     'swap-quadrants.cl',

--- a/src/kernels/phase-retrieval.cl
+++ b/src/kernels/phase-retrieval.cl
@@ -108,35 +108,41 @@ kernel void
 ctf_method(float2 prefac, float regularize_rate, float binary_filter_rate, float frequency_cutoff, global float *output)
 {
     COMMON_SETUP;
+    float db = pow (10, regularize_rate); /* History, delta/beta = 10^R */
+    float H = db * sin_value + 1.0f;
 
-    if (fabs (sin_value + pow(10, -regularize_rate)) < 1e-7 || sin_arg >= frequency_cutoff || (idx == 0 && idy == 0))
+    if (fabs (H) < 1e-7 || sin_arg >= frequency_cutoff || (idx == 0 && idy == 0))
         output[idy * width + idx] = 0.0f;
     else
-        output[idy * width + idx] = 0.5f / (sin_value + pow(10, -regularize_rate));
+        output[idy * width + idx] = 1.0f / H;
 }
 
 kernel void
 qp_method(float2 prefac, float regularize_rate, float binary_filter_rate, float frequency_cutoff, global float *output)
 {
     COMMON_SETUP;
+    float db = pow (10, regularize_rate); /* History, delta/beta = 10^R */
+    float H = db * sin_value + 1.0f;
 
-    if ((sin_arg > M_PI_2_F && fabs (sin_value + pow(10, -regularize_rate)) < binary_filter_rate) ||
+    if ((sin_arg > M_PI_2_F && fabs (H) < db * binary_filter_rate) ||
         sin_arg >= frequency_cutoff || (idx == 0 && idy == 0))
         /* Zero frequency (idx == 0 && idy == 0) must be set to zero explicitly */
         output[idy * width + idx] = 0.0f;
     else
-        output[idy * width + idx] = 0.5f / (sin_value + pow(10, -regularize_rate));
+        output[idy * width + idx] = 1.0f / H;
 }
 
 kernel void
 qp2_method(float2 prefac, float regularize_rate, float binary_filter_rate, float frequency_cutoff, global float *output)
 {
     COMMON_SETUP;
-    float cacl_filter_value = 0.5f / (sin_value + pow(10, -regularize_rate));
+    float db = pow (10, regularize_rate); /* History, delta/beta = 10^R */
+    float H = db * sin_value + 1.0f;
+    float cacl_filter_value = 1.0f / H;
 
-    if ((sin_arg > M_PI_2_F && fabs(sin_value + pow(10, -regularize_rate)) < binary_filter_rate) ||
+    if ((sin_arg > M_PI_2_F && fabs(H) < db * binary_filter_rate) ||
         sin_arg >= frequency_cutoff || (idx == 0 && idy == 0))
-        output[idy * width + idx] = sign(cacl_filter_value) / (2 * (binary_filter_rate + pow(10, -regularize_rate)));
+        output[idy * width + idx] = sign(cacl_filter_value) / (db * binary_filter_rate + 1.0f);
     else
         output[idy * width + idx] = cacl_filter_value;
 }

--- a/src/kernels/phase-retrieval.cl
+++ b/src/kernels/phase-retrieval.cl
@@ -59,10 +59,9 @@ kernel void
 tie_method(float2 prefac, float regularize_rate, float binary_filter_rate, float frequency_cutoff, global float *output)
 {
     COMMON_SETUP_TIE;
-    if (sin_arg >= frequency_cutoff)
-        output[idy * width + idx] = 0.0f;
-    else
-        output[idy * width + idx] = 0.5f / (sin_arg + pow(10, -regularize_rate));
+    float db = pow (10, regularize_rate); /* History, delta/beta = 10^R */
+
+    output[idy * width + idx] = 1.0f / (db * sin_arg + 1.0f);
 }
 
 kernel void

--- a/src/kernels/sharpening.cl
+++ b/src/kernels/sharpening.cl
@@ -74,9 +74,7 @@ frequency_sharpen_lorentz (global float *input,
 {
     COMMON_DIGITAL_FREQUENCY_SETUP;
     const float radius = sqrt (freq_x * freq_x + freq_y * freq_y);
-    const float h_inv = exp (M_PI_F * radius * fwhm);
-    const float highpass = h_inv - 1.0f;
-    const float raw = strength * highpass;
+    const float raw = strength * (exp (M_PI_F * radius * fwhm) - 1.0f);
     const float factor = 1.0f + limit_boost (raw, max_boost);
 
     output[index] = input[index] * factor;

--- a/src/kernels/sharpening.cl
+++ b/src/kernels/sharpening.cl
@@ -30,13 +30,22 @@
     freq_x = freq_x / real_width;                                     \
     freq_y = freq_y / height;
 
+inline float
+limit_boost (const float raw,
+             const float max_boost)
+{
+    return max_boost > 0.0f ? max_boost * tanh (raw / max_boost) : raw;
+}
+
 kernel void
 frequency_sharpen_laplace (global float *input,
                            global float *output,
-                           const float strength)
+                           const float strength,
+                           const float max_boost)
 {
     COMMON_DIGITAL_FREQUENCY_SETUP;
-    const float factor = 1.0f + 4.0f * M_PI_F * M_PI_F * strength * (freq_x * freq_x + freq_y * freq_y);
+    const float raw = 4.0f * M_PI_F * M_PI_F * strength * (freq_x * freq_x + freq_y * freq_y);
+    const float factor = 1.0f + limit_boost (raw, max_boost);
 
     output[index] = input[index] * factor;
 }
@@ -44,12 +53,14 @@ frequency_sharpen_laplace (global float *input,
 kernel void
 frequency_sharpen_discrete_laplace (global float *input,
                                     global float *output,
-                                    const float strength)
+                                    const float strength,
+                                    const float max_boost)
 {
     COMMON_DIGITAL_FREQUENCY_SETUP;
     const float sx = sin (M_PI_F * freq_x);
     const float sy = sin (M_PI_F * freq_y);
-    const float factor = 1.0f + 4.0f * strength * (sx * sx + sy * sy);
+    const float raw = 4.0f * strength * (sx * sx + sy * sy);
+    const float factor = 1.0f + limit_boost (raw, max_boost);
 
     output[index] = input[index] * factor;
 }
@@ -58,13 +69,15 @@ kernel void
 frequency_sharpen_lorentz (global float *input,
                            global float *output,
                            const float strength,
+                           const float max_boost,
                            const float fwhm)
 {
     COMMON_DIGITAL_FREQUENCY_SETUP;
     const float radius = sqrt (freq_x * freq_x + freq_y * freq_y);
     const float h_inv = exp (M_PI_F * radius * fwhm);
     const float highpass = h_inv - 1.0f;
-    const float factor = 1.0f + strength * highpass;
+    const float raw = strength * highpass;
+    const float factor = 1.0f + limit_boost (raw, max_boost);
 
     output[index] = input[index] * factor;
 }

--- a/src/kernels/sharpening.cl
+++ b/src/kernels/sharpening.cl
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define COMMON_DIGITAL_FREQUENCY_SETUP                                \
+    const int width = get_global_size (0);                            \
+    const int height = get_global_size (1);                           \
+    const int real_width = width >> 1;                                \
+    const int idx = get_global_id (0);                                \
+    const int idy = get_global_id (1);                                \
+    const int index = idy * width + idx;                              \
+    const int fidx = idx >> 1;                                        \
+    float freq_x = (fidx >= real_width >> 1) ? fidx - real_width : fidx; \
+    float freq_y = (idy >= height >> 1) ? idy - height : idy;         \
+    freq_x = freq_x / real_width;                                     \
+    freq_y = freq_y / height;
+
+kernel void
+frequency_sharpen_laplace (global float *input,
+                           global float *output,
+                           const float strength)
+{
+    COMMON_DIGITAL_FREQUENCY_SETUP;
+    const float factor = 1.0f + 4.0f * M_PI_F * M_PI_F * strength * (freq_x * freq_x + freq_y * freq_y);
+
+    output[index] = input[index] * factor;
+}
+
+kernel void
+frequency_sharpen_discrete_laplace (global float *input,
+                                    global float *output,
+                                    const float strength)
+{
+    COMMON_DIGITAL_FREQUENCY_SETUP;
+    const float sx = sin (M_PI_F * freq_x);
+    const float sy = sin (M_PI_F * freq_y);
+    const float factor = 1.0f + 4.0f * strength * (sx * sx + sy * sy);
+
+    output[index] = input[index] * factor;
+}
+
+kernel void
+frequency_sharpen_lorentz (global float *input,
+                           global float *output,
+                           const float strength,
+                           const float fwhm)
+{
+    COMMON_DIGITAL_FREQUENCY_SETUP;
+    const float radius = sqrt (freq_x * freq_x + freq_y * freq_y);
+    const float h_inv = exp (M_PI_F * radius * fwhm);
+    const float highpass = h_inv - 1.0f;
+    const float factor = 1.0f + strength * highpass;
+
+    output[index] = input[index] * factor;
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,6 +26,7 @@ plugins = [
     'flatten-inplace',
     'flat-field-correct',
     'fftmult',
+    'frequency-sharpen',
     'filter-particle',
     'filter-stripes',
     'filter-stripes1d',

--- a/src/ufo-frequency-sharpen-task.c
+++ b/src/ufo-frequency-sharpen-task.c
@@ -1,0 +1,312 @@
+/*
+ * Copyright (C) 2026
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#ifdef __APPLE__
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
+
+#include "ufo-frequency-sharpen-task.h"
+
+typedef enum {
+    METHOD_LAPLACE = 0,
+    METHOD_DISCRETE_LAPLACE,
+    METHOD_LORENTZ,
+    N_METHODS
+} UfoFrequencySharpenMethod;
+
+struct _UfoFrequencySharpenTaskPrivate {
+    cl_kernel kernels[N_METHODS];
+
+    gfloat strength;
+    gfloat lorentz_fwhm;
+    UfoFrequencySharpenMethod method;
+    gchar *method_name;
+};
+
+static void ufo_task_interface_init (UfoTaskIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (UfoFrequencySharpenTask, ufo_frequency_sharpen_task, UFO_TYPE_TASK_NODE,
+                         G_IMPLEMENT_INTERFACE (UFO_TYPE_TASK,
+                                                ufo_task_interface_init))
+
+#define UFO_FREQUENCY_SHARPEN_TASK_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE((obj), UFO_TYPE_FREQUENCY_SHARPEN_TASK, UfoFrequencySharpenTaskPrivate))
+
+enum {
+    PROP_0,
+    PROP_STRENGTH,
+    PROP_METHOD,
+    PROP_LORENTZ_FWHM,
+    N_PROPERTIES
+};
+
+static GParamSpec *properties[N_PROPERTIES] = { NULL, };
+
+static UfoFrequencySharpenMethod
+parse_method (const gchar *method)
+{
+    if (g_strcmp0 (method, "laplace") == 0)
+        return METHOD_LAPLACE;
+
+    if (g_strcmp0 (method, "discrete-laplace") == 0)
+        return METHOD_DISCRETE_LAPLACE;
+
+    if (g_strcmp0 (method, "lorentz") == 0)
+        return METHOD_LORENTZ;
+
+    return N_METHODS;
+}
+
+UfoNode *
+ufo_frequency_sharpen_task_new (void)
+{
+    return UFO_NODE (g_object_new (UFO_TYPE_FREQUENCY_SHARPEN_TASK, NULL));
+}
+
+static gboolean
+ufo_frequency_sharpen_task_process (UfoTask *task,
+                                    UfoBuffer **inputs,
+                                    UfoBuffer *output,
+                                    UfoRequisition *requisition)
+{
+    UfoFrequencySharpenTaskPrivate *priv;
+    UfoGpuNode *node;
+    UfoProfiler *profiler;
+    cl_command_queue cmd_queue;
+    cl_mem in_mem;
+    cl_mem out_mem;
+    cl_kernel kernel;
+
+    priv = UFO_FREQUENCY_SHARPEN_TASK_GET_PRIVATE (task);
+    node = UFO_GPU_NODE (ufo_task_node_get_proc_node (UFO_TASK_NODE (task)));
+    cmd_queue = ufo_gpu_node_get_cmd_queue (node);
+    in_mem = ufo_buffer_get_device_array (inputs[0], cmd_queue);
+    out_mem = ufo_buffer_get_device_array (output, cmd_queue);
+    kernel = priv->kernels[priv->method];
+
+    ufo_buffer_set_layout (output, UFO_BUFFER_LAYOUT_COMPLEX_INTERLEAVED);
+
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 0, sizeof (cl_mem), &in_mem));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 1, sizeof (cl_mem), &out_mem));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 2, sizeof (cl_float), &priv->strength));
+
+    if (priv->method == METHOD_LORENTZ)
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 3, sizeof (cl_float), &priv->lorentz_fwhm));
+
+    profiler = ufo_task_node_get_profiler (UFO_TASK_NODE (task));
+    ufo_profiler_call (profiler, cmd_queue, kernel, 2, requisition->dims, NULL);
+
+    return TRUE;
+}
+
+static void
+ufo_frequency_sharpen_task_setup (UfoTask *task,
+                                  UfoResources *resources,
+                                  GError **error)
+{
+    UfoFrequencySharpenTaskPrivate *priv;
+
+    priv = UFO_FREQUENCY_SHARPEN_TASK_GET_PRIVATE (task);
+
+    priv->kernels[METHOD_LAPLACE] = ufo_resources_get_kernel (resources, "sharpening.cl", "frequency_sharpen_laplace", NULL, error);
+    priv->kernels[METHOD_DISCRETE_LAPLACE] = ufo_resources_get_kernel (resources, "sharpening.cl", "frequency_sharpen_discrete_laplace", NULL, error);
+    priv->kernels[METHOD_LORENTZ] = ufo_resources_get_kernel (resources, "sharpening.cl", "frequency_sharpen_lorentz", NULL, error);
+
+    for (guint i = 0; i < N_METHODS; i++) {
+        if (priv->kernels[i] != NULL)
+            UFO_RESOURCES_CHECK_SET_AND_RETURN (clRetainKernel (priv->kernels[i]), error);
+    }
+}
+
+static void
+ufo_frequency_sharpen_task_get_requisition (UfoTask *task,
+                                            UfoBuffer **inputs,
+                                            UfoRequisition *requisition,
+                                            GError **error)
+{
+    ufo_buffer_get_requisition (inputs[0], requisition);
+}
+
+static guint
+ufo_frequency_sharpen_task_get_num_inputs (UfoTask *task)
+{
+    return 1;
+}
+
+static guint
+ufo_frequency_sharpen_task_get_num_dimensions (UfoTask *task,
+                                               guint input)
+{
+    g_return_val_if_fail (input == 0, 0);
+    return 2;
+}
+
+static UfoTaskMode
+ufo_frequency_sharpen_task_get_mode (UfoTask *task)
+{
+    return UFO_TASK_MODE_PROCESSOR | UFO_TASK_MODE_GPU;
+}
+
+static void
+ufo_frequency_sharpen_task_set_property (GObject *object,
+                                         guint property_id,
+                                         const GValue *value,
+                                         GParamSpec *pspec)
+{
+    UfoFrequencySharpenTaskPrivate *priv;
+
+    priv = UFO_FREQUENCY_SHARPEN_TASK_GET_PRIVATE (object);
+
+    switch (property_id) {
+        case PROP_STRENGTH:
+            priv->strength = g_value_get_float (value);
+            break;
+        case PROP_METHOD:
+            if (parse_method (g_value_get_string (value)) != N_METHODS) {
+                g_free (priv->method_name);
+                priv->method_name = g_value_dup_string (value);
+                priv->method = parse_method (priv->method_name);
+            }
+            else {
+                g_warning ("Unknown frequency sharpening method '%s', keeping '%s'",
+                           g_value_get_string (value), priv->method_name);
+            }
+            break;
+        case PROP_LORENTZ_FWHM:
+            priv->lorentz_fwhm = g_value_get_float (value);
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+            break;
+    }
+}
+
+static void
+ufo_frequency_sharpen_task_get_property (GObject *object,
+                                         guint property_id,
+                                         GValue *value,
+                                         GParamSpec *pspec)
+{
+    UfoFrequencySharpenTaskPrivate *priv;
+
+    priv = UFO_FREQUENCY_SHARPEN_TASK_GET_PRIVATE (object);
+
+    switch (property_id) {
+        case PROP_STRENGTH:
+            g_value_set_float (value, priv->strength);
+            break;
+        case PROP_METHOD:
+            g_value_set_string (value, priv->method_name);
+            break;
+        case PROP_LORENTZ_FWHM:
+            g_value_set_float (value, priv->lorentz_fwhm);
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+            break;
+    }
+}
+
+static void
+ufo_frequency_sharpen_task_finalize (GObject *object)
+{
+    UfoFrequencySharpenTaskPrivate *priv;
+
+    priv = UFO_FREQUENCY_SHARPEN_TASK_GET_PRIVATE (object);
+
+    for (guint i = 0; i < N_METHODS; i++) {
+        if (priv->kernels[i]) {
+            UFO_RESOURCES_CHECK_CLERR (clReleaseKernel (priv->kernels[i]));
+            priv->kernels[i] = NULL;
+        }
+    }
+
+    g_free (priv->method_name);
+    priv->method_name = NULL;
+
+    G_OBJECT_CLASS (ufo_frequency_sharpen_task_parent_class)->finalize (object);
+}
+
+static void
+ufo_task_interface_init (UfoTaskIface *iface)
+{
+    iface->setup = ufo_frequency_sharpen_task_setup;
+    iface->get_requisition = ufo_frequency_sharpen_task_get_requisition;
+    iface->get_num_inputs = ufo_frequency_sharpen_task_get_num_inputs;
+    iface->get_num_dimensions = ufo_frequency_sharpen_task_get_num_dimensions;
+    iface->get_mode = ufo_frequency_sharpen_task_get_mode;
+    iface->process = ufo_frequency_sharpen_task_process;
+}
+
+static void
+ufo_frequency_sharpen_task_class_init (UfoFrequencySharpenTaskClass *klass)
+{
+    GObjectClass *oclass;
+
+    oclass = G_OBJECT_CLASS (klass);
+
+    oclass->set_property = ufo_frequency_sharpen_task_set_property;
+    oclass->get_property = ufo_frequency_sharpen_task_get_property;
+    oclass->finalize = ufo_frequency_sharpen_task_finalize;
+
+    properties[PROP_STRENGTH] =
+        g_param_spec_float ("strength",
+            "Sharpening strength",
+            "Strength of the frequency-domain sharpening filter",
+            0.0f, G_MAXFLOAT, 1.0f,
+            G_PARAM_READWRITE);
+
+    properties[PROP_METHOD] =
+        g_param_spec_string ("method",
+            "Sharpening method",
+            "Frequency-domain sharpening method",
+            "laplace",
+            G_PARAM_READWRITE);
+
+    properties[PROP_LORENTZ_FWHM] =
+        g_param_spec_float ("lorentz-fwhm",
+            "Lorentz FWHM",
+            "Full width at half maximum of the Lorentz blur kernel",
+            0.0f, G_MAXFLOAT, 1.0f,
+            G_PARAM_READWRITE);
+
+    for (guint i = PROP_0 + 1; i < N_PROPERTIES; i++)
+        g_object_class_install_property (oclass, i, properties[i]);
+
+    g_type_class_add_private (klass, sizeof (UfoFrequencySharpenTaskPrivate));
+}
+
+static void
+ufo_frequency_sharpen_task_init (UfoFrequencySharpenTask *self)
+{
+    UfoFrequencySharpenTaskPrivate *priv;
+
+    self->priv = priv = UFO_FREQUENCY_SHARPEN_TASK_GET_PRIVATE (self);
+
+    for (guint i = 0; i < N_METHODS; i++)
+        priv->kernels[i] = NULL;
+
+    priv->strength = 1.0f;
+    priv->lorentz_fwhm = 1.0f;
+    priv->method = METHOD_LAPLACE;
+    priv->method_name = g_strdup ("laplace");
+}

--- a/src/ufo-frequency-sharpen-task.c
+++ b/src/ufo-frequency-sharpen-task.c
@@ -166,6 +166,40 @@ ufo_frequency_sharpen_task_get_mode (UfoTask *task)
     return UFO_TASK_MODE_PROCESSOR | UFO_TASK_MODE_GPU;
 }
 
+static UfoNode *
+ufo_frequency_sharpen_task_copy_real (UfoNode *node,
+                                      GError **error)
+{
+    UfoFrequencySharpenTask *orig;
+    UfoFrequencySharpenTask *copy;
+
+    orig = UFO_FREQUENCY_SHARPEN_TASK (node);
+    copy = UFO_FREQUENCY_SHARPEN_TASK (ufo_frequency_sharpen_task_new ());
+
+    g_object_set (G_OBJECT (copy),
+                  "strength", orig->priv->strength,
+                  "method", orig->priv->method_name,
+                  "lorentz-fwhm", orig->priv->lorentz_fwhm,
+                  NULL);
+
+    return UFO_NODE (copy);
+}
+
+static gboolean
+ufo_frequency_sharpen_task_equal_real (UfoNode *n1,
+                                       UfoNode *n2)
+{
+    UfoFrequencySharpenTaskPrivate *priv1;
+    UfoFrequencySharpenTaskPrivate *priv2;
+
+    g_return_val_if_fail (UFO_IS_FREQUENCY_SHARPEN_TASK (n1) && UFO_IS_FREQUENCY_SHARPEN_TASK (n2), FALSE);
+
+    priv1 = UFO_FREQUENCY_SHARPEN_TASK_GET_PRIVATE (n1);
+    priv2 = UFO_FREQUENCY_SHARPEN_TASK_GET_PRIVATE (n2);
+
+    return priv1->kernels[priv1->method] == priv2->kernels[priv2->method];
+}
+
 static void
 ufo_frequency_sharpen_task_set_property (GObject *object,
                                          guint property_id,
@@ -261,8 +295,10 @@ static void
 ufo_frequency_sharpen_task_class_init (UfoFrequencySharpenTaskClass *klass)
 {
     GObjectClass *oclass;
+    UfoNodeClass *node_class;
 
     oclass = G_OBJECT_CLASS (klass);
+    node_class = UFO_NODE_CLASS (klass);
 
     oclass->set_property = ufo_frequency_sharpen_task_set_property;
     oclass->get_property = ufo_frequency_sharpen_task_get_property;
@@ -291,6 +327,9 @@ ufo_frequency_sharpen_task_class_init (UfoFrequencySharpenTaskClass *klass)
 
     for (guint i = PROP_0 + 1; i < N_PROPERTIES; i++)
         g_object_class_install_property (oclass, i, properties[i]);
+
+    node_class->copy = ufo_frequency_sharpen_task_copy_real;
+    node_class->equal = ufo_frequency_sharpen_task_equal_real;
 
     g_type_class_add_private (klass, sizeof (UfoFrequencySharpenTaskPrivate));
 }

--- a/src/ufo-frequency-sharpen-task.c
+++ b/src/ufo-frequency-sharpen-task.c
@@ -39,6 +39,7 @@ struct _UfoFrequencySharpenTaskPrivate {
 
     gfloat strength;
     gfloat lorentz_fwhm;
+    gfloat max_boost;
     UfoFrequencySharpenMethod method;
     gchar *method_name;
 };
@@ -56,6 +57,7 @@ enum {
     PROP_STRENGTH,
     PROP_METHOD,
     PROP_LORENTZ_FWHM,
+    PROP_MAX_BOOST,
     N_PROPERTIES
 };
 
@@ -108,9 +110,10 @@ ufo_frequency_sharpen_task_process (UfoTask *task,
     UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 0, sizeof (cl_mem), &in_mem));
     UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 1, sizeof (cl_mem), &out_mem));
     UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 2, sizeof (cl_float), &priv->strength));
+    UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 3, sizeof (cl_float), &priv->max_boost));
 
     if (priv->method == METHOD_LORENTZ)
-        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 3, sizeof (cl_float), &priv->lorentz_fwhm));
+        UFO_RESOURCES_CHECK_CLERR (clSetKernelArg (kernel, 4, sizeof (cl_float), &priv->lorentz_fwhm));
 
     profiler = ufo_task_node_get_profiler (UFO_TASK_NODE (task));
     ufo_profiler_call (profiler, cmd_queue, kernel, 2, requisition->dims, NULL);
@@ -180,6 +183,7 @@ ufo_frequency_sharpen_task_copy_real (UfoNode *node,
                   "strength", orig->priv->strength,
                   "method", orig->priv->method_name,
                   "lorentz-fwhm", orig->priv->lorentz_fwhm,
+                  "max-boost", orig->priv->max_boost,
                   NULL);
 
     return UFO_NODE (copy);
@@ -228,6 +232,9 @@ ufo_frequency_sharpen_task_set_property (GObject *object,
         case PROP_LORENTZ_FWHM:
             priv->lorentz_fwhm = g_value_get_float (value);
             break;
+        case PROP_MAX_BOOST:
+            priv->max_boost = g_value_get_float (value);
+            break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
             break;
@@ -253,6 +260,9 @@ ufo_frequency_sharpen_task_get_property (GObject *object,
             break;
         case PROP_LORENTZ_FWHM:
             g_value_set_float (value, priv->lorentz_fwhm);
+            break;
+        case PROP_MAX_BOOST:
+            g_value_set_float (value, priv->max_boost);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -325,6 +335,13 @@ ufo_frequency_sharpen_task_class_init (UfoFrequencySharpenTaskClass *klass)
             0.0f, G_MAXFLOAT, 1.0f,
             G_PARAM_READWRITE);
 
+    properties[PROP_MAX_BOOST] =
+        g_param_spec_float ("max-boost",
+            "Maximum boost",
+            "Maximum additional sharpening boost; 0 disables tanh limiting",
+            0.0f, G_MAXFLOAT, 0.0f,
+            G_PARAM_READWRITE);
+
     for (guint i = PROP_0 + 1; i < N_PROPERTIES; i++)
         g_object_class_install_property (oclass, i, properties[i]);
 
@@ -346,6 +363,7 @@ ufo_frequency_sharpen_task_init (UfoFrequencySharpenTask *self)
 
     priv->strength = 1.0f;
     priv->lorentz_fwhm = 1.0f;
+    priv->max_boost = 0.0f;
     priv->method = METHOD_LAPLACE;
     priv->method_name = g_strdup ("laplace");
 }

--- a/src/ufo-frequency-sharpen-task.h
+++ b/src/ufo-frequency-sharpen-task.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026
+ *
+ * This file is part of Ufo.
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __UFO_FREQUENCY_SHARPEN_TASK_H
+#define __UFO_FREQUENCY_SHARPEN_TASK_H
+
+#include <ufo/ufo.h>
+
+G_BEGIN_DECLS
+
+#define UFO_TYPE_FREQUENCY_SHARPEN_TASK             (ufo_frequency_sharpen_task_get_type())
+#define UFO_FREQUENCY_SHARPEN_TASK(obj)             (G_TYPE_CHECK_INSTANCE_CAST((obj), UFO_TYPE_FREQUENCY_SHARPEN_TASK, UfoFrequencySharpenTask))
+#define UFO_IS_FREQUENCY_SHARPEN_TASK(obj)          (G_TYPE_CHECK_INSTANCE_TYPE((obj), UFO_TYPE_FREQUENCY_SHARPEN_TASK))
+#define UFO_FREQUENCY_SHARPEN_TASK_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST((klass), UFO_TYPE_FREQUENCY_SHARPEN_TASK, UfoFrequencySharpenTaskClass))
+#define UFO_IS_FREQUENCY_SHARPEN_TASK_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE((klass), UFO_TYPE_FREQUENCY_SHARPEN_TASK))
+#define UFO_FREQUENCY_SHARPEN_TASK_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS((obj), UFO_TYPE_FREQUENCY_SHARPEN_TASK, UfoFrequencySharpenTaskClass))
+
+typedef struct _UfoFrequencySharpenTask           UfoFrequencySharpenTask;
+typedef struct _UfoFrequencySharpenTaskClass      UfoFrequencySharpenTaskClass;
+typedef struct _UfoFrequencySharpenTaskPrivate    UfoFrequencySharpenTaskPrivate;
+
+/**
+ * UfoFrequencySharpenTask:
+ *
+ * Main object for organizing filters. The contents of the
+ * #UfoFrequencySharpenTask structure are private and should only be
+ * accessed via the provided API.
+ */
+struct _UfoFrequencySharpenTask {
+    /*< private >*/
+    UfoTaskNode parent_instance;
+
+    UfoFrequencySharpenTaskPrivate *priv;
+};
+
+/**
+ * UfoFrequencySharpenTaskClass:
+ *
+ * #UfoFrequencySharpenTask class
+ */
+struct _UfoFrequencySharpenTaskClass {
+    /*< private >*/
+    UfoTaskNodeClass parent_class;
+};
+
+UfoNode  *ufo_frequency_sharpen_task_new       (void);
+GType     ufo_frequency_sharpen_task_get_type  (void);
+
+G_END_DECLS
+
+#endif


### PR DESCRIPTION
## Summary

This PR adds a new `frequency-sharpen` task for sharpening 2D data directly in Fourier space.

The task accepts one 2D complex interleaved input, for example the output of `fft dimensions=2`, and produces one 2D complex interleaved output suitable for `ifft dimensions=2`.

## Changes

- Added `frequency-sharpen` as a new UFO task/plugin.
- Added a dedicated OpenCL kernel file, `sharpening.cl`.
- Added `frequency-sharpen` to the Meson and CMake builds.
- Added `sharpening.cl` to Meson's explicit kernel install list.
- Documented the new task and properties in `docs/filters.rst`.

## Methods

The task exposes a `method` string property with three supported values:

- `laplace`: classical Laplace sharpening using the continuous frequency response.
- `discrete-laplace`: discrete Laplace sharpening using the digital finite-difference response.
- `lorentz`: Lorentz deconvolution-style high-pass sharpening.

The common `strength` property controls the blend strength for all methods.

The `lorentz` method also adds:

- `lorentz-fwhm`: full width at half maximum of the Lorentz blur kernel.

## Implementation Notes

The OpenCL kernels use a shared macro to compute signed normalized digital frequencies from approximately `-0.5` to `0.5`.

The classical Laplace method applies:

```c
1 + 4 * pi^2 * strength * (freq_x^2 + freq_y^2)
```

The discrete Laplace method applies:

```c
1 + 4 * strength * (sin^2(pi * freq_x) + sin^2(pi * freq_y))
```

The Lorentz method applies the frequency-space equivalent of:

```python
Hinv = exp(2 * pi * abs(u) * fwhm / 2)
highpass = Hinv - 1
result = image + strength * ifft2(fft2(image) * highpass).real
```

Parts of this PR were AI-generated.